### PR TITLE
Item height needed to be reduced by one since it was determining the …

### DIFF
--- a/SourceGen/RuntimeData/Apple/VisHiRes.cs
+++ b/SourceGen/RuntimeData/Apple/VisHiRes.cs
@@ -283,7 +283,7 @@ namespace RuntimeData.Apple {
             }
 
             int lastOffset = offset + (cellStride * (count - 1)) +
-                rowStride * itemHeight - (colStride - 1) - 1;
+                rowStride * (itemHeight - (colStride - 1) - 1);
             if (lastOffset >= mFileData.Length) {
                 mAppRef.ReportError("Bitmap runs off end of file (last offset +" +
                     lastOffset.ToString("x6") + ")");


### PR DESCRIPTION
…size to be too large.  Fixed bug in which it stated it was oversized when it wasn't.

Parenthesis was missing which caused a math error.