### PR TITLE
Added SNES coprocessor symbol file

### DIFF
--- a/SourceGen/RuntimeData/Nintendo/SNES-SA-1.sym65
+++ b/SourceGen/RuntimeData/Nintendo/SNES-SA-1.sym65
@@ -1,0 +1,113 @@
+; 6502bench SNES SA-1 registers symbol
+; Reference:
+;   Super Nintendo Entertainment System Development Manual
+;   Registers | Super Famicom Development Wiki
+;     https://wiki.superfamicom.org/sa-1-registers
+; Copyright 2022 absindx
+;   Follow the original license. (Apache 2.0)
+
+*SYNOPSIS Super NES SA-1 registers
+
+; SA-1 internal registers
+;   bank = $00-$3F, $80-$BF
+;   %?0??????xxxxxxxxxxxxxxxx
+;   %010000000000000000000000   CompareMask  (0/1)
+;   %000000000000000000000000   CompareValue (1)
+;   %000000001111111111111111   AddressMask  (x)
+*MULTI_MASK %010000000000000000000000 %000000000000000000000000 %000000001111111111111111
+
+; Write registers $xx2200
+
+SA1_CCNT        > $2200 ;W IRrN mmmm  SA-1 CPU control
+SA1_SIE         > $2201 ;W I-C- ----  Super NES CPU int enable
+SA1_SIC         > $2202 ;W I-C- ----  Super NES CPU int clear
+SA1_CRVL        > $2203 ;W aaaa aaaa  SA-1 CPU reset vector (Low)
+SA1_CRVH        > $2204 ;W aaaa aaaa  SA-1 CPU reset vector (High)
+SA1_CNVL        > $2205 ;W aaaa aaaa  SA-1 CPU NMI vector (Low)
+SA1_CNVH        > $2206 ;W aaaa aaaa  SA-1 CPU NMI vector (High)
+SA1_CIVL        > $2207 ;W aaaa aaaa  SA-1 CPU IRQ vector (Low)
+SA1_CIVH        > $2208 ;W aaaa aaaa  SA-1 CPU IRQ vector (High)
+SA1_SCNT        > $2209 ;W IS-N mmmm  Super NES CPU control
+SA1_CIE         > $220A ;W ITDN ----  SA-1 CPU int enable
+SA1_CIC         > $220B ;W ITDN ----  SA-1 CPU int clear
+SA1_SNVL        > $220C ;W aaaa aaaa  Super NES CPU NMI vector (Low)
+SA1_SNVH        > $220D ;W aaaa aaaa  Super NES CPU NMI vector (High)
+SA1_SIVL        > $220E ;W aaaa aaaa  Super NES CPU IRQ vector (Low)
+SA1_SIVH        > $220F ;W aaaa aaaa  Super NES CPU IRQ vector (High)
+SA1_TMC         > $2210 ;W T--- --VH   H/V timer control
+SA1_CTR         > $2211 ;W ---- ----  SA-1 CPU timer restart
+SA1_HCNTL       > $2212 ;W HHHH HHHH  Set H-Count (Low)
+SA1_HCNTH       > $2213 ;W ---- ---H  Set H-Count (High)
+SA1_VCNTL       > $2214 ;W VVVV VVVV  Set V-Count (Low)
+SA1_VCNTH       > $2215 ;W ---- ---V  Set V-Count (High)
+
+SA1_CXB         > $2220 ;W B--- -AAA  Set Super MMC bank C
+SA1_DXB         > $2221 ;W B--- -AAA  Set Super MMC bank D
+SA1_EXB         > $2222 ;W B--- -AAA  Set Super MMC bank E
+SA1_FXB         > $2223 ;W B--- -AAA  Set Super MMC bank F
+SA1_BMAPS       > $2224 ;W ---B BBBB  Super NES CPU BW-RAM address mapping
+SA1_BMAP        > $2225 ;W SBBB BBBB  SA-1 CPU BW-RAM address mapping
+SA1_SBWE        > $2226 ;W P--- ----  Super NES CPU BW-RAM write enable
+SA1_CBWE        > $2227 ;W P--- ----  SA-1 CPU BW-RAM write enable
+SA1_BWPA        > $2228 ;W ---- AAAA  BW-RAM Write-Protected area
+SA1_SIWP        > $2229 ;W 7654 3210  Super NES I-RAM wirte protection
+SA1_CIWP        > $222A ;W 7654 3210  SA-1 I-RAM wirte protection
+
+SA1_DCNT        > $2230 ;W CPMT -DSS  DMA control
+SA1_CDMA        > $2231 ;W E--S SSCC  Character conversion DMA parameters
+SA1_SDAL        > $2232 ;W AAAA AAAA  DMA source device start address (Low)
+SA1_SDAH        > $2233 ;W AAAA AAAA  DMA source device start address (Middle)
+SA1_SDAB        > $2234 ;W AAAA AAAA  DMA source device start address (High)
+SA1_DDAL        > $2235 ;W AAAA AAAA  DMA destination start address (Low)
+SA1_DDAH        > $2236 ;W AAAA AAAA  DMA destination start address (Middle)
+SA1_DDAB        > $2237 ;W AAAA AAAA  DMA destination start address (High)
+SA1_DTCL        > $2238 ;W CCCC CCCC  DMA terminal counter (Low)
+SA1_DTCH        > $2239 ;W CCCC CCCC  DMA terminal counter (High)
+
+SA1_BBF         > $223F ;W C--- ----  BW-RAM bit map format
+SA1_BRF0        > $2240 ;W BBBB BBBB  Bit map register file (Buffer 1)
+SA1_BRF1        > $2241 ;W BBBB BBBB  Bit map register file (Buffer 1)
+SA1_BRF2        > $2242 ;W BBBB BBBB  Bit map register file (Buffer 1)
+SA1_BRF3        > $2243 ;W BBBB BBBB  Bit map register file (Buffer 1)
+SA1_BRF4        > $2244 ;W BBBB BBBB  Bit map register file (Buffer 1)
+SA1_BRF5        > $2245 ;W BBBB BBBB  Bit map register file (Buffer 1)
+SA1_BRF6        > $2246 ;W BBBB BBBB  Bit map register file (Buffer 1)
+SA1_BRF7        > $2247 ;W BBBB BBBB  Bit map register file (Buffer 1)
+SA1_BRF8        > $2248 ;W BBBB BBBB  Bit map register file (Buffer 2)
+SA1_BRF9        > $2249 ;W BBBB BBBB  Bit map register file (Buffer 2)
+SA1_BRFA        > $224A ;W BBBB BBBB  Bit map register file (Buffer 2)
+SA1_BRFB        > $224B ;W BBBB BBBB  Bit map register file (Buffer 2)
+SA1_BRFC        > $224C ;W BBBB BBBB  Bit map register file (Buffer 2)
+SA1_BRFD        > $224D ;W BBBB BBBB  Bit map register file (Buffer 2)
+SA1_BRFE        > $224E ;W BBBB BBBB  Bit map register file (Buffer 2)
+SA1_BRFF        > $224F ;W BBBB BBBB  Bit map register file (Buffer 2)
+SA1_MCNT        > $2250 ;W ---- --OO  Arithmetic control
+SA1_MAL         > $2251 ;W NNNN NNNN  Arithmetic parameters: Multiplicand / Dividend (Low)
+SA1_MAH         > $2252 ;W NNNN NNNN  Arithmetic parameters: Multiplicand / Dividend (High)
+SA1_MBL         > $2253 ;W NNNN NNNN  Arithmetic parameters: Multiplier / Divisor (Low)
+SA1_MBH         > $2254 ;W NNNN NNNN  Arithmetic parameters: Multiplier / Divisor (High)
+
+SA1_VBD         > $2258 ;W H--- VVVV  Variable-Length bit processing
+SA1_VDAL        > $2259 ;W AAAA AAAA  Variable-Length bit game pak ROM start address (Low)
+SA1_VDAH        > $225A ;W AAAA AAAA  Variable-Length bit game pak ROM start address (Middle)
+SA1_VDAB        > $225B ;W AAAA AAAA  Variable-Length bit game pak ROM start address (High)
+
+; Read registers $xx2300
+
+SA1_SFR         < $2300 ;R IVDN mmmm  Super NES CPU flag read
+SA1_CFR         < $2301 ;R ITDN mmmm  SA-1 CPU flag read
+SA1_HCRL        < $2302 ;R HHHH HHHH  H-Count read (Low)
+SA1_HCRH        < $2303 ;R ---- ---H  H-Count read (High)
+SA1_VCRL        < $2304 ;R VVVV VVVV  V-Count read (Low)
+SA1_VCRH        < $2305 ;R ---- ---V  V-Count read (High)
+SA1_MR1         < $2306 ;R DDDD DDDD  Arithmetic result (product/quotient/cumulative sum)
+SA1_MR2         < $2307 ;R DDDD DDDD  Arithmetic result (product/quotient/cumulative sum)
+SA1_MR3         < $2308 ;R DDDD DDDD  Arithmetic result (product/remainder/cumulative sum)
+SA1_MR4         < $2309 ;R DDDD DDDD  Arithmetic result (product/remainder/cumulative sum)
+SA1_MR5         < $230A ;R DDDD DDDD  Arithmetic result (cumulative sum)
+SA1_OF          < $230B ;R O--- ----  Arithmetic overflow flag
+SA1_VDPL        < $230C ;R DDDD DDDD  Variable-Length data read port (Low)
+SA1_VDPH        < $230D ;R DDDD DDDD  Variable-Length data read port (High)
+SA1_VC          < $230E ;R VVVV VVVV  Version code register
+
+

--- a/SourceGen/RuntimeData/Nintendo/SNES-SuperFX.sym65
+++ b/SourceGen/RuntimeData/Nintendo/SNES-SuperFX.sym65
@@ -1,0 +1,70 @@
+; 6502bench SNES Super FX registers symbol
+; Reference:
+;   Super Nintendo Entertainment System Development Manual
+; Copyright 2022 absindx
+;   Follow the original license. (Apache 2.0)
+
+*SYNOPSIS Super NES Super FX registers
+
+; GSU internal registers $xx3000
+;   bank = $00-$3F, $80-$BF
+;   %?0??????xxxxxxxxxxxxxxxx
+;   %010000000000000000000000   CompareMask  (0/1)
+;   %000000000000000000000000   CompareValue (1)
+;   %000000001111111111111111   AddressMask  (x)
+*MULTI_MASK %010000000000000000000000 %000000000000000000000000 %000000001111111111111111
+
+; General registers
+
+GSU_R0L         @ $3000 ;RW DDDD DDDD  Default source/destination register (Low)
+GSU_R0H         @ $3001 ;RW DDDD DDDD  Default source/destination register (High)
+GSU_R1L         @ $3002 ;RW DDDD DDDD  PLOT instruction, X coordinate (Low)
+GSU_R1H         @ $3003 ;RW DDDD DDDD  PLOT instruction, X coordinate (High)
+GSU_R2L         @ $3004 ;RW DDDD DDDD  PLOT instruction, Y coordinate (Low)
+GSU_R2H         @ $3005 ;RW DDDD DDDD  PLOT instruction, Y coordinate (High)
+GSU_R3L         @ $3006 ;RW DDDD DDDD  General register (Low)
+GSU_R3H         @ $3007 ;RW DDDD DDDD  General register (High)
+GSU_R4L         @ $3008 ;RW DDDD DDDD  LMULT instruction, lower 16 bits (Low)
+GSU_R4H         @ $3009 ;RW DDDD DDDD  LMULT instruction, lower 16 bits (High)
+GSU_R5L         @ $300A ;RW DDDD DDDD  General register (Low)
+GSU_R5H         @ $300B ;RW DDDD DDDD  General register (High)
+GSU_R6L         @ $300C ;RW DDDD DDDD  FMULT and LMULT instructions, multiplication (Low)
+GSU_R6H         @ $300D ;RW DDDD DDDD  FMULT and LMULT instructions, multiplication (High)
+GSU_R7L         @ $300E ;RW DDDD DDDD  MERGE instruction, source1 (Low)
+GSU_R7H         @ $300F ;RW DDDD DDDD  MERGE instruction, source1 (High)
+GSU_R8L         @ $3010 ;RW DDDD DDDD  MERGE instruction, source2 (Low)
+GSU_R8H         @ $3011 ;RW DDDD DDDD  MERGE instruction, source2 (High)
+GSU_R9L         @ $3012 ;RW DDDD DDDD  General register (Low)
+GSU_R9H         @ $3013 ;RW DDDD DDDD  General register (High)
+GSU_R10L        @ $3014 ;RW DDDD DDDD  General register (Low)
+GSU_R10H        @ $3015 ;RW DDDD DDDD  General register (High)
+GSU_R11L        @ $3016 ;RW DDDD DDDD  LINK instruction destination register (Low)
+GSU_R11H        @ $3017 ;RW DDDD DDDD  LINK instruction destination register (High)
+GSU_R12L        @ $3018 ;RW DDDD DDDD  LOOP instruction counter (Low)
+GSU_R12H        @ $3019 ;RW DDDD DDDD  LOOP instruction counter (High)
+GSU_R13L        @ $301A ;RW DDDD DDDD  LOOP instruction branch (Low)
+GSU_R13H        @ $301B ;RW DDDD DDDD  LOOP instruction branch (High)
+GSU_R14L        @ $301C ;RW AAAA AAAA  Game pak ROM address pointer (Low)
+GSU_R14H        @ $301D ;RW AAAA AAAA  Game pak ROM address pointer (High)
+GSU_R15L        @ $301E ;RW PPPP PPPP  Program counter (Low)
+GSU_R15H        @ $301F ;RW PPPP PPPP  Program counter (High)
+
+; Other registers
+
+GSU_SFRL        @ $3030 ;RW -RGO SCZ-  Flag register
+GSU_SFRH        @ $3031 ;RW I--B HL21  Status register
+GSU_PBR         @ $3034 ;RW AAAA AAAA  Program bank register
+GSU_ROMBR       < $3036 ;R AAAA AAAA  Game pak ROM bank register
+GSU_RAMBR       < $303C ;RW ---- ---A  Game pak RAM bank register
+GSU_CBRL        < $303E ;RW AAAA ----  Cache base register (Low)
+GSU_CBRH        < $303F ;RW AAAA AAAA  Cache base register (High)
+GSU_SCBR        > $3038 ;W AAAA AAAA  Screen base register
+GSU_SCMR        > $303A ;W --HE EHGG  Screen mode register
+;GSU_COLR       - $30xx ;- CCCC CCCC  Color register (Not accessible from Super NES)
+;GSU_POR        - $30xx ;- ---O FNDT  Plot option register (Not accessible from Super NES)
+GSU_BRAMR       > $3033 ;W ---- ---B  Back-up RAM register
+GSU_VCR         < $303B ;R VVVV VVVV  Version code register
+GSU_CFGR        > $3037 ;W I-S- ----  Config register
+GSU_CLSR        > $3039 ;W ---- ---C  Clock select register
+
+

--- a/SourceGen/RuntimeData/Nintendo/SNES.sym65
+++ b/SourceGen/RuntimeData/Nintendo/SNES.sym65
@@ -3,127 +3,138 @@
 ;   Super Nintendo Entertainment System Development Manual
 ;   Registers | Super Famicom Development Wiki
 ;     https://wiki.superfamicom.org/registers
-; Copyright 2021 absindx
+;   Memory map - SNESdev Wiki
+;     https://snes.nesdev.org/wiki/Memory_map
+; Copyright 2021-2022 absindx
 ;   Follow the original license. (Apache 2.0)
 
 *SYNOPSIS Super NES registers
 
-*MULTI_MASK
+; I/O registers $xx2000
+;   bank = $00-$3F, $80-$BF
+;   page = $2000-$6F00
+;   %?0??????xxxxxxxxxxxxxxxx
+;   %010000000000000000000000	CompareMask  (0/1)
+;   %000000000000000000000000	CompareValue (1)
+;   %000000001111111111111111	AddressMask  (x)
+*MULTI_MASK %010000000000000000000000 %000000000000000000000000 %000000001111111111111111
 
 ; PPU registers (Address Bus B)
 
-INIDISP         @ $2100 ;W B--- FFFF  Initial settings for screen
-OBJSEL          @ $2101 ;W SSSN NAAA  Object size & Object data area designation
-OAMADDL         @ $2102 ;W AAAA AAAA  Address for accessing OAM (Low)
-OAMADDH         @ $2103 ;W P--- ---A  Address for accessing OAM (High)
-OAMDATA         @ $2104 ;W DDDD DDDD  Data for OAM write
-BGMODE          @ $2105 ;W SSSS PMMM  BG mode & Character size settings
-MOSAIC          @ $2106 ;W MMMM EEEE  Size & Screen designation for mosaic display
-BG1SC           @ $2107 ;W AAAA AASS  Address for storing SC-data of each BG & SC size designation (Mode 0-6) (BG-1)
-BG2SC           @ $2108 ;W AAAA AASS  Address for storing SC-data of each BG & SC size designation (Mode 0-6) (BG-2)
-BG3SC           @ $2109 ;W AAAA AASS  Address for storing SC-data of each BG & SC size designation (Mode 0-6) (BG-3)
-BG4SC           @ $210A ;W AAAA AASS  Address for storing SC-data of each BG & SC size designation (Mode 0-6) (BG-4)
-BG12NBA         @ $210B ;W 2222 1111  BG character data area designation (BG-1, 2)
-BG34NBA         @ $210C ;W 4444 3333  BG character data area designation (BG-3, 4)
-BG1HOFS         @ $210D ;WW XXXX XXXX, ---X XXXX  H scroll value designation for BG-1
-BG1VOFS         @ $210E ;WW XXXX XXXX, ---X XXXX  V scroll value designation for BG-1
-BG2HOFS         @ $210F ;WW XXXX XXXX, ---- --XX  H scroll value designation for BG-2
-BG2VOFS         @ $2110 ;WW XXXX XXXX, ---- --XX  V scroll value designation for BG-2
-BG3HOFS         @ $2111 ;WW XXXX XXXX, ---- --XX  H scroll value designation for BG-3
-BG3VOFS         @ $2112 ;WW XXXX XXXX, ---- --XX  V scroll value designation for BG-3
-BG4HOFS         @ $2113 ;WW XXXX XXXX, ---- --XX  H scroll value designation for BG-4
-BG4VOFS         @ $2114 ;WW XXXX XXXX, ---- --XX  V scroll value designation for BG-4
-VMAINC          @ $2115 ;W T--- GGII  VRAM address increment value designation
-VMADDL          @ $2116 ;W AAAA AAAA  Address for VRAM read and write (Low)
-VMADDH          @ $2117 ;W AAAA AAAA  Address for VRAM read and write (High)
-VMDATAL         @ $2118 ;W AAAA AAAA  Data for VRAM write (Low)
-VMDATAH         @ $2119 ;W AAAA AAAA  Data for VRAM write (High)
-M7SEL           @ $211A ;W SS-- --VH  Initial setting in screen Mode-7
-M7A             @ $211B ;WW AAAA AAAA, AAAA AAAA  Rotation/Enlargement/Reduction in Mode-7, Matrix parameter A (Low, High)
-M7B             @ $211C ;WW BBBB BBBB, BBBB BBBB  Rotation/Enlargement/Reduction in Mode-7, Matrix parameter B (Low, High)
-M7C             @ $211D ;WW CCCC CCCC, CCCC CCCC  Rotation/Enlargement/Reduction in Mode-7, Matrix parameter C (Low, High)
-M7D             @ $211E ;WW DDDD DDDD, DDDD DDDD  Rotation/Enlargement/Reduction in Mode-7, Matrix parameter D (Low, High)
-M7X             @ $211F ;WW XXXX XXXX, ---X XXXX  Rotation/Enlargement/Reduction in Mode-7, Center position X0 (Low, High)
-M7Y             @ $2120 ;WW YYYY YYYY, ---Y YYYY  Rotation/Enlargement/Reduction in Mode-7, Center position Y0 (Low, High)
-CGADD           @ $2121 ;W AAAA AAAA  Address for CG-RAM read and write
-CGDATA          @ $2122 ;WW DDDD DDDD, -DDD DDDD  Data for CG-RAM write
-W12SEL          @ $2123 ;W EIEI EIEI  Window mask settings (BG-1, 2)
-W34SEL          @ $2124 ;W EIEI EIEI  Window mask settings (BG-3, 4)
-WOBJSEL         @ $2125 ;W EIEI EIEI  Window mask settings (OBJ, Color)
-WH0             @ $2126 ;W PPPP PPPP  Window position designation (Window-1 left position)
-WH1             @ $2127 ;W PPPP PPPP  Window position designation (Window-1 right position)
-WH2             @ $2128 ;W PPPP PPPP  Window position designation (Window-2 left position)
-WH3             @ $2129 ;W PPPP PPPP  Window position designation (Window-2 right position)
-WBGLOG          @ $212A ;W 4433 2211  Mask logic settings for Window-1 & 2 on each screen
-WOBJLOG         @ $212B ;W ---- CCOO  Mask logic settings for Window-1 & 2 on each screen
-TM              @ $212C ;W ---O 4321  Main screen designation
-TS              @ $212D ;W ---O 4321  Sub screen designation
-TMW             @ $212E ;W ---O 4321  Window mask designation for main screen
-TSW             @ $212F ;W ---O 4321  Window mask designation for sub screen
-CGSWSEL         @ $2130 ;W MMSS --CD  Initial settings for fixed color addition on screen addition
-CGADSUB         @ $2131 ;W SEBO 4321  Addition/Subtraction & Subtraction designation for each BG screen OBJ & Background color
-COLDATA         @ $2132 ;W BGRD DDDD  Fixed color data for fixed color addition/subtraction
-SETINI          @ $2133 ;W SI-- PBOI  Screen initial setting
-MPYL            @ $2134 ;R MMMM MMMM  Multiplication result (Low)
-MPYM            @ $2135 ;R MMMM MMMM  Multiplication result (Middle)
-MPYH            @ $2136 ;R MMMM MMMM  Multiplication result (High)
-SLHV            @ $2137 ;- SSSS SSSS  Software latch for H/V counter
-OAMDATA         @ $2138 ;RR DDDD DDDD, DDDD DDDD  Read data from OAM
-VMDATAL         @ $2139 ;R DDDD DDDD  Read data from VRAM (Low)
-VMDATAH         @ $213A ;R DDDD DDDD  Read data from VRAM (High)
-CGDATA          @ $213B ;RR DDDD DDDD, -DDD DDDD  Read data from CG-RAM
-OPHCT           @ $213C ;RR HHHH HHHH, ---- ---H  H counter data by external or software latch
-OPVCT           @ $213D ;RR VVVV VVVV, ---- ---V  V counter data by external or software latch
-STAT77          @ $213E ;R TRM- VVVV  PPU status flag & Version number (5C77)
-STAT78          @ $213F ;R FL-D VVVV  PPU status flag & Version number (5C78)
+INIDISP         > $2100 ;W B--- FFFF  Initial settings for screen
+OBJSEL          > $2101 ;W SSSN NAAA  Object size & Object data area designation
+OAMADDL         > $2102 ;W AAAA AAAA  Address for accessing OAM (Low)
+OAMADDH         > $2103 ;W P--- ---A  Address for accessing OAM (High)
+OAMDATA         > $2104 ;W DDDD DDDD  Data for OAM write
+BGMODE          > $2105 ;W SSSS PMMM  BG mode & Character size settings
+MOSAIC          > $2106 ;W MMMM EEEE  Size & Screen designation for mosaic display
+BG1SC           > $2107 ;W AAAA AASS  Address for storing SC-data of each BG & SC size designation (Mode 0-6) (BG-1)
+BG2SC           > $2108 ;W AAAA AASS  Address for storing SC-data of each BG & SC size designation (Mode 0-6) (BG-2)
+BG3SC           > $2109 ;W AAAA AASS  Address for storing SC-data of each BG & SC size designation (Mode 0-6) (BG-3)
+BG4SC           > $210A ;W AAAA AASS  Address for storing SC-data of each BG & SC size designation (Mode 0-6) (BG-4)
+BG12NBA         > $210B ;W 2222 1111  BG character data area designation (BG-1, 2)
+BG34NBA         > $210C ;W 4444 3333  BG character data area designation (BG-3, 4)
+BG1HOFS         > $210D ;WW XXXX XXXX, ---X XXXX  H scroll value designation for BG-1
+BG1VOFS         > $210E ;WW XXXX XXXX, ---X XXXX  V scroll value designation for BG-1
+BG2HOFS         > $210F ;WW XXXX XXXX, ---- --XX  H scroll value designation for BG-2
+BG2VOFS         > $2110 ;WW XXXX XXXX, ---- --XX  V scroll value designation for BG-2
+BG3HOFS         > $2111 ;WW XXXX XXXX, ---- --XX  H scroll value designation for BG-3
+BG3VOFS         > $2112 ;WW XXXX XXXX, ---- --XX  V scroll value designation for BG-3
+BG4HOFS         > $2113 ;WW XXXX XXXX, ---- --XX  H scroll value designation for BG-4
+BG4VOFS         > $2114 ;WW XXXX XXXX, ---- --XX  V scroll value designation for BG-4
+VMAINC          > $2115 ;W T--- GGII  VRAM address increment value designation
+VMADDL          > $2116 ;W AAAA AAAA  Address for VRAM read and write (Low)
+VMADDH          > $2117 ;W AAAA AAAA  Address for VRAM read and write (High)
+VMDATAL         > $2118 ;W AAAA AAAA  Data for VRAM write (Low)
+VMDATAH         > $2119 ;W AAAA AAAA  Data for VRAM write (High)
+M7SEL           > $211A ;W SS-- --VH  Initial setting in screen Mode-7
+M7A             > $211B ;WW AAAA AAAA, AAAA AAAA  Rotation/Enlargement/Reduction in Mode-7, Matrix parameter A (Low, High)
+M7B             > $211C ;WW BBBB BBBB, BBBB BBBB  Rotation/Enlargement/Reduction in Mode-7, Matrix parameter B (Low, High)
+M7C             > $211D ;WW CCCC CCCC, CCCC CCCC  Rotation/Enlargement/Reduction in Mode-7, Matrix parameter C (Low, High)
+M7D             > $211E ;WW DDDD DDDD, DDDD DDDD  Rotation/Enlargement/Reduction in Mode-7, Matrix parameter D (Low, High)
+M7X             > $211F ;WW XXXX XXXX, ---X XXXX  Rotation/Enlargement/Reduction in Mode-7, Center position X0 (Low, High)
+M7Y             > $2120 ;WW YYYY YYYY, ---Y YYYY  Rotation/Enlargement/Reduction in Mode-7, Center position Y0 (Low, High)
+CGADD           > $2121 ;W AAAA AAAA  Address for CG-RAM read and write
+CGDATA          > $2122 ;WW DDDD DDDD, -DDD DDDD  Data for CG-RAM write
+W12SEL          > $2123 ;W EIEI EIEI  Window mask settings (BG-1, 2)
+W34SEL          > $2124 ;W EIEI EIEI  Window mask settings (BG-3, 4)
+WOBJSEL         > $2125 ;W EIEI EIEI  Window mask settings (OBJ, Color)
+WH0             > $2126 ;W PPPP PPPP  Window position designation (Window-1 left position)
+WH1             > $2127 ;W PPPP PPPP  Window position designation (Window-1 right position)
+WH2             > $2128 ;W PPPP PPPP  Window position designation (Window-2 left position)
+WH3             > $2129 ;W PPPP PPPP  Window position designation (Window-2 right position)
+WBGLOG          > $212A ;W 4433 2211  Mask logic settings for Window-1 & 2 on each screen
+WOBJLOG         > $212B ;W ---- CCOO  Mask logic settings for Window-1 & 2 on each screen
+TM              > $212C ;W ---O 4321  Main screen designation
+TS              > $212D ;W ---O 4321  Sub screen designation
+TMW             > $212E ;W ---O 4321  Window mask designation for main screen
+TSW             > $212F ;W ---O 4321  Window mask designation for sub screen
+CGSWSEL         > $2130 ;W MMSS --CD  Initial settings for fixed color addition on screen addition
+CGADSUB         > $2131 ;W SEBO 4321  Addition/Subtraction & Subtraction designation for each BG screen OBJ & Background color
+COLDATA         > $2132 ;W BGRD DDDD  Fixed color data for fixed color addition/subtraction
+SETINI          > $2133 ;W SI-- PBOI  Screen initial setting
+MPYL            < $2134 ;R MMMM MMMM  Multiplication result (Low)
+MPYM            < $2135 ;R MMMM MMMM  Multiplication result (Middle)
+MPYH            < $2136 ;R MMMM MMMM  Multiplication result (High)
+SLHV            < $2137 ;R ---- ----  Software latch for H/V counter
+OAMDATAREAD     < $2138 ;RR DDDD DDDD, DDDD DDDD  Read data from OAM
+VMDATALREAD     < $2139 ;R DDDD DDDD  Read data from VRAM (Low)
+VMDATAHREAD     < $213A ;R DDDD DDDD  Read data from VRAM (High)
+CGDATAREAD      < $213B ;RR DDDD DDDD, -DDD DDDD  Read data from CG-RAM
+OPHCT           < $213C ;RR HHHH HHHH, ---- ---H  H counter data by external or software latch
+OPVCT           < $213D ;RR VVVV VVVV, ---- ---V  V counter data by external or software latch
+STAT77          < $213E ;R TRM- VVVV  PPU status flag & Version number (5C77)
+STAT78          < $213F ;R FL-D VVVV  PPU status flag & Version number (5C78)
 APUIO0          @ $2140 ;RW DDDD DDDD  Communication port with APU
 APUIO1          @ $2141 ;RW DDDD DDDD  Communication port with APU
 APUIO2          @ $2142 ;RW DDDD DDDD  Communication port with APU
 APUIO3          @ $2143 ;RW DDDD DDDD  Communication port with APU
 WMDATA          @ $2180 ;RW DDDD DDDD  DATA to consecutively read from and write to WRAM
-WMADDL          @ $2181 ;W AAAA AAAA  Address to consecutively read and write WRAM (Low)
-WMADDM          @ $2182 ;W AAAA AAAA  Address to consecutively read and write WRAM (Middle)
-WMADDH          @ $2183 ;W ---- ---A  Address to consecutively read and write WRAM (High)
+WMADDL          > $2181 ;W AAAA AAAA  Address to consecutively read and write WRAM (Low)
+WMADDM          > $2182 ;W AAAA AAAA  Address to consecutively read and write WRAM (Middle)
+WMADDH          > $2183 ;W ---- ---A  Address to consecutively read and write WRAM (High)
+
+
 
 ; CPU registers (Internal)
 
-NMITIMEN        @ $4200 ;W N-VH ---C  Enable flag for V-Blank, Timer interrupt & Standard controller read
-WRIO            @ $4201 ;W DDDD DDDD  Programmable I/O port (Out port)
-WRMPYA          @ $4202 ;W AAAA AAAA  Multiplicand by multiplication
-WRMPYB          @ $4203 ;W BBBB BBBB  Multiplier by multiplication
-WRDIVL          @ $4204 ;W CCCC CCCC  Dividend by divide (Low)
-WRDIVH          @ $4205 ;W CCCC CCCC  Dividend by divide (High)
-WRDIVB          @ $4206 ;W BBBB BBBB  Divisor by divide
-HTIMEL          @ $4207 ;W HHHH HHHH  H-count timer settings (Low)
-HTIMEH          @ $4208 ;W ---- ---H  H-count timer settings (High)
-VTIMEL          @ $4209 ;W VVVV VVVV  V-count timer settings (Low)
-VTIMEH          @ $420A ;W ---- ---V  V-count timer settings (High)
-MDMAEN          @ $420B ;W 7654 3210  Channel designation for general purpose DMA & Trigger (start)
-HDMAEN          @ $420C ;W 7654 3210  Channel designation for H-DMA
-MEMSEL          @ $420D ;W ---- ---A  Access cycle designation in memory [2] area
-RDNMI           @ $4210 ;R N--- VVVV  NMI flag by V-Blank & Version number
-TIMEUP          @ $4211 ;R T--- ----  IRQ flag by H/V count timer
-HVBJOY          @ $4212 ;R VH-- ---C  H/V Blank flag & Standard controller enable flag
-RDIO            @ $4213 ;R DDDD DDDD  Programmable I/O port (In port)
-RDDIVL          @ $4214 ;R AAAA AAAA  Quotient of divide result (Low)
-RDDIVH          @ $4215 ;R AAAA AAAA  Quotient of divide result (High)
-RDMPYL          @ $4216 ;R CCCC CCCC  Product of multiplication result or remainder of divide result (Low)
-RDMPYH          @ $4217 ;R CCCC CCCC  Product of multiplication result or remainder of divide result (High)
-STDCNTRL1L      @ $4218 ;R AXLR ----  Data for standard controller 1 (Low)
-STDCNTRL1H      @ $4219 ;R BYST UDLR  Data for standard controller 1 (High)
-STDCNTRL2L      @ $421A ;R AXLR ----  Data for standard controller 2 (Low)
-STDCNTRL2H      @ $421B ;R BYST UDLR  Data for standard controller 2 (High)
-STDCNTRL3L      @ $421C ;R AXLR ----  Data for standard controller 3 (Low)
-STDCNTRL3H      @ $421D ;R BYST UDLR  Data for standard controller 3 (High)
-STDCNTRL4L      @ $421E ;R AXLR ----  Data for standard controller 4 (Low)
-STDCNTRL4H      @ $421F ;R BYST UDLR  Data for standard controller 4 (High)
+NMITIMEN        > $4200 ;W N-VH ---C  Enable flag for V-Blank, Timer interrupt & Standard controller read
+WRIO            > $4201 ;W DDDD DDDD  Programmable I/O port (Out port)
+WRMPYA          > $4202 ;W AAAA AAAA  Multiplicand by multiplication
+WRMPYB          > $4203 ;W BBBB BBBB  Multiplier by multiplication
+WRDIVL          > $4204 ;W CCCC CCCC  Dividend by divide (Low)
+WRDIVH          > $4205 ;W CCCC CCCC  Dividend by divide (High)
+WRDIVB          > $4206 ;W BBBB BBBB  Divisor by divide
+HTIMEL          > $4207 ;W HHHH HHHH  H-count timer settings (Low)
+HTIMEH          > $4208 ;W ---- ---H  H-count timer settings (High)
+VTIMEL          > $4209 ;W VVVV VVVV  V-count timer settings (Low)
+VTIMEH          > $420A ;W ---- ---V  V-count timer settings (High)
+MDMAEN          > $420B ;W 7654 3210  Channel designation for general purpose DMA & Trigger (start)
+HDMAEN          > $420C ;W 7654 3210  Channel designation for H-DMA
+MEMSEL          > $420D ;W ---- ---A  Access cycle designation in memory [2] area
+RDNMI           < $4210 ;R N--- VVVV  NMI flag by V-Blank & Version number
+TIMEUP          < $4211 ;R T--- ----  IRQ flag by H/V count timer
+HVBJOY          < $4212 ;R VH-- ---C  H/V Blank flag & Standard controller enable flag
+RDIO            < $4213 ;R DDDD DDDD  Programmable I/O port (In port)
+RDDIVL          < $4214 ;R AAAA AAAA  Quotient of divide result (Low)
+RDDIVH          < $4215 ;R AAAA AAAA  Quotient of divide result (High)
+RDMPYL          < $4216 ;R CCCC CCCC  Product of multiplication result or remainder of divide result (Low)
+RDMPYH          < $4217 ;R CCCC CCCC  Product of multiplication result or remainder of divide result (High)
+STDCNTRL1L      < $4218 ;R AXLR ----  Data for standard controller 1 (Low)
+STDCNTRL1H      < $4219 ;R BYST UDLR  Data for standard controller 1 (High)
+STDCNTRL2L      < $421A ;R AXLR ----  Data for standard controller 2 (Low)
+STDCNTRL2H      < $421B ;R BYST UDLR  Data for standard controller 2 (High)
+STDCNTRL3L      < $421C ;R AXLR ----  Data for standard controller 3 (Low)
+STDCNTRL3H      < $421D ;R BYST UDLR  Data for standard controller 3 (High)
+STDCNTRL4L      < $421E ;R AXLR ----  Data for standard controller 4 (Low)
+STDCNTRL4H      < $421F ;R BYST UDLR  Data for standard controller 4 (High)
 
 
 
 ; Old Style Joypad Registers
 
 JOYSER0         @ $4016 ;R:---- --31 W:---- -xxL
-JOYSER1         @ $4017 ;R ---- --42
+JOYSER1         < $4017 ;R ---- --42
 
 
 


### PR DESCRIPTION
Created symbols for the SA-1 and Super FX coprocessors found in [some SNES games](https://en.wikipedia.org/wiki/List_of_Super_NES_enhancement_chips).
These control registers are accessed by the CPU (65C816) as memory-mapped I/O.
It's not included as standard, so I decided it wasn't necessary to add it to the system definition.

Also made some corrections to the previously created SNES symbol files.