### PR TITLE
Additional C64 .sym65 support files

### DIFF
--- a/SourceGen/RuntimeData/Commodore/1541-RAM-use.sym65
+++ b/SourceGen/RuntimeData/Commodore/1541-RAM-use.sym65
@@ -99,8 +99,8 @@ driveNum        @ $007f      ;Drive number (on 1541 always 00)
 curTrk          @ $0080      ;Current Track number
 curSec          @ $0081      ;Current Sector number
 chnlNum         @ $0082      ;Channel number (Logical index)
-2ndAddr         @ $0083      ;Secondary address
-2ndAddrOriginal @ $0084      ;Original Secondary address $6f
+scndAddr        @ $0083      ;Secondary address
+scndAddrOrig    @ $0084      ;Original Secondary address $6f
 curDataByte     @ $0085      ;Current Data byte $3f
 tmpArea4        @ $0086 9    ;Temp Results area
 curBufPtr       @ $0094 2    ;Current dir buffer pointer

--- a/SourceGen/RuntimeData/Commodore/1541-RAM-use.sym65
+++ b/SourceGen/RuntimeData/Commodore/1541-RAM-use.sym65
@@ -1,0 +1,203 @@
+; See the LICENSE file for distribution terms (Apache 2.0).
+;
+; Parts adapted from multiple sources:
+;
+; - Commodore 1541 / OC-118 Disk Drive Memory Map (v1.3, Jan 18, 1995)
+;   https://ist.uwaterloo.ca/~schepers/MJK/ascii/1541map.txt
+;
+; - Commodore 1541 drive memory map
+;   https://sta.c64.org/cbm1541mem.html
+;
+; - DOS 2.6 ROM LISTINGS (v1.0, Feb 11, 2000)
+;   http://www.ffd2.com/fridge/docs/1541dis.html
+;
+; - CBM DOS ROM disassembly and memory variables for Commodore 1541 drive
+;   https://g3sl.github.io/c1541rom.html
+
+*SYNOPSIS 1541 RAM locations used by the 1541 ROM
+
+cmdCodeBuf0     @ $0000      ;Command code for buffer 0
+cmdCodeBuf1     @ $0001      ;Command code for buffer 1
+cmdCodeBuf2     @ $0002      ;Command code for buffer 2
+cmdCodeBuf3     @ $0003      ;Command code for buffer 3
+cmdCodeBuf4     @ $0004      ;Command code for buffer 4
+trkBuf0         @ $0006      ;Track buffer 0
+secBuf0         @ $0007      ;Sector buffer 0
+trkBuf1         @ $0008      ;Track buffer 1
+secBuf1         @ $0009      ;Sector buffer 1
+trkBuf2         @ $000a      ;Track buffer 2
+secBuf2         @ $000b      ;Sector buffer 2
+trkBuf3         @ $000c      ;Track buffer 3
+secBuf3         @ $000d      ;Sector buffer 3
+trkBuf4         @ $000e      ;Track buffer 4
+secBuf4         @ $000f      ;Sector buffer 4
+d0DiskID        @ $0012      ;Disk ID, drive 0
+d1DiskID        @ $0014      ;Disk ID, drive 1
+hbID            @ $0016      ;Header block: ID
+hbTrk           @ $0018      ;Header block: Track
+hbSec           @ $0019      ;Header block: Sector
+hbParity        @ $001a      ;Header block: Parity
+diskChgD0       @ $001c      ;Flag for disk change, drive 0 01
+diskChgD1       @ $001d      ;Flag for disk change, drive 1 01
+writeProtD0     @ $001e      ;Flag for write protect sense, drive 0 01
+writeProtD1     @ $001f      ;Flag for write protect sense, drive 1
+d0Status        @ $0020      ;Drive 0 status (disk and step motor)
+d1Status        @ $0021      ;Drive 1 status (disk and step motor)
+d0CurTrk        @ $0022      ;Current track for drive 0
+driveType       @ $0023      ;Flag for 1541 (0), 1540 (not 0)
+gcrWorkArea     @ $0024      ;Scratch pad of GCR conversion
+ptrTmpMem       @ $002e 2    ;Pointer for temporary storage
+bufPtrCtrl      @ $0030 2    ;Buffer pointer for disk controller
+ptrCurTrk       @ $0032 2    ;Pointer: active track
+ptrCurSec       @ $0033 2    ;Pointer: active sector
+ptrLastConvByte @ $0034 2    ;Pointer to last converted byte
+convByteCnt     @ $0036      ;Byte counter for GCR/BIN conversion
+byteStartBlk    @ $0038      ;Constant 7, ID mark for start of data block
+byteStartBlkHdr @ $0039      ;Constant 8, ID mark for start of block header
+dataBufParity   @ $003a      ;Parity for data buffer
+motorFlag       @ $003d      ;Motor flag
+curDrive        @ $003e      ;Active drive (FF, if not active)
+ctrlBufNum      @ $003f      ;Buffer number for disk controller
+gcrConvByteCnt  @ $0040      ;Byte counter for GCR conversion
+workCnt         @ $0041      ;Number of next work in queue (0 - 5)
+destTrk         @ $0042      ;Destination track (to move R/W head to)
+secPerTrk       @ $0043      ;Number of sectors per track for formatting
+tmpArea         @ $0044      ;Temp. work area; Scratch pad
+tmpArea2        @ $0045      ;Work code temp. storage
+byteBlkID       @ $0047      ;Data block ID char, default 07.
+headMoveCnt     @ $0048      ;Counter for head movement
+headStepCnt     @ $004a      ;Step counter for head transport
+lastReadSec     @ $004c      ;Last read sector
+nextSec         @ $004d      ;Next sector
+gcrConvBufPtr   @ $004e 2    ;Pointer to buffer for GCR->BIN conversion
+gcrFormatFlag   @ $0050      ;Flag for GCR format (0=BIN, 1=GCR)
+curFormatTrk    @ $0051      ;Current track number for formatting FF
+gcrConvBytesBuf @ $0052 4    ;Storage for 4 BIN bytes for GCR coding
+gcrConvStore    @ $0056 5    ;Storage for 5 GCR bytes
+headAccSteps    @ $005e      ;Number of steps for head motor accel/decl
+headAccFactor   @ $005f      ;accelerating/decl. factor 04
+headMoveVec     @ $0062 2    ;Pointer to routine for head movement $fa05
+headStepsMin    @ $0064      ;Minimum number of steps C8
+nmiVec          @ $0065 2    ;Pointer to start of NMI routine ($eb2e)
+nmiInProc       @ $0067      ;Flag: NMI in process
+diskInitInProc  @ $0068      ;Flag for disk initialisation
+secDivStepSize  @ $0069      ;Step size for sector division $0a
+numReadAttempts @ $006a      ;Number of read attempts 5
+ptrStartJumpTbl @ $006b 2    ;Pointer: Start of Jump table for U commands $ffea
+ptrStartBitmap  @ $006d 2    ;Pointer: Start of bitmap $0400
+ptrMBcmds       @ $006f 2    ;Pointer to address for M & B commands
+tmpArea3        @ $0071 4    ;Temp work area
+indPtrVar       @ $0075 2    ;Indirect pointer variable ($0100)
+listenAddr      @ $0077      ;Listener address (Device number + $20)
+talkAddr        @ $0078      ;Talker address (Device number + $40)
+curListenFlag   @ $0079      ;Flag: Active listener
+curTalkFlag     @ $007a      ;Flag: Active talker
+atnRecevFlag    @ $007c      ;Flag for ATN from serial bus receiving
+atnActiveFlag   @ $007d      ;Flag for ATN on serial bus active
+lastPrg         @ $007e      ;Last handled program
+driveNum        @ $007f      ;Drive number (on 1541 always 00)
+curTrk          @ $0080      ;Current Track number
+curSec          @ $0081      ;Current Sector number
+chnlNum         @ $0082      ;Channel number (Logical index)
+2ndAddr         @ $0083      ;Secondary address
+2ndAddrOriginal @ $0084      ;Original Secondary address $6f
+curDataByte     @ $0085      ;Current Data byte $3f
+tmpArea4        @ $0086 9    ;Temp Results area
+curBufPtr       @ $0094 2    ;Current dir buffer pointer
+ptrNxtByteBuf0  @ $0099 2    ;Pointer: Next byte in buffer 0 $0300
+ptrNxtByteBuf1  @ $009b 2    ;Pointer: Next byte in buffer 1 $0400
+ptrNxtByteBuf2  @ $009d 2    ;Pointer: Next byte in buffer 2 $0500
+ptrNxtByteBuf3  @ $009f 2    ;Pointer: Next byte in buffer 3 $0600
+ptrNxtByteBuf4  @ $00a1 2    ;Pointer: Next byte in buffer 4 $0700
+ptrNxtByteCmdBf @ $00a3 2    ;Pointer: Next byte in command buffer $0200
+prtNxtByteErrBf @ $00a5 2    ;Pointer: Next byte in error message buffer $02d6
+tblBufChnls     @ $00a7      ;Table: buffer channel assignments
+tblLoBufRecNum  @ $00b5 6    ;Table: lo bytes of record numbers for each buffer
+tblHiBufRecNum  @ $00bb 6    ;Table: hi bytes of record numbers for each buffer
+relWritePtr     @ $00c1      ;Write pointer for REL file
+relRecLen       @ $00c7      ;Table: Record length for REL file
+tblSideSecs     @ $00cd 6    ;Table: Side sectors
+relInRecPtr     @ $00d4      ;Pointer in record for REL file
+sideSecNum      @ $00d5      ;Side sector number
+blkPrtSideSec   @ $00d6      ;Pointer to data block in side sector
+relToRecPtr2    @ $00d7      ;Pointer to record in REL file
+dirSectors      @ $00d8      ;Directory sectors
+indexDir        @ $00dd      ;Index: Directory
+defaultDrive    @ $00e2      ;Default disk drive 00
+chnlStatus      @ $00f2      ;Channel status
+flatEOI         @ $00f8      ;Flag for EOI
+currWorkBufNum  @ $00f9      ;Current work (Buffer number)
+lruTable        @ $00fa 5    ;Least recently used table
+d0ReadyFlag     @ $00ff      ;Flag: FF = drive 0 not ready (No disk), 00 = ready
+d1ReadyFlag     @ $0100      ;Flag: FF = drive 1 not ready (No disk), 00 = ready
+d0FormatMarker  @ $0101      ;DOS version from t18 for drive 0
+d1FormatMarker  @ $0102      ;DOS version from t18 for drive 1
+cmdStrBuf       @ $0200 42   ;Buffer for command string
+cmdCode         @ $022a      ;Command code
+chnl1Index      @ $022b      ;Logical index, channel 0
+chnl2Index      @ $022c      ;Logical index, channel 1
+chnl3Index      @ $022d      ;Logical index, channel 2
+chnlsLastRWbyte @ $022e 6    ;Last read/written byte for each channel
+chnlsLastChar   @ $0244 6    ;Pointer: Last char on channel
+curFileType     @ $024a      ;Type of active file
+strLen          @ $024b      ;String length
+tmpChnlNum      @ $024c      ;Temp. channel number (secondary address)
+curWork         @ $024d      ;Current work with drive number
+workAreaForSec  @ $024e      ;Work area to find the best sector
+bufAlloc        @ $024f      ;Buffer allocated
+d0BamChangFlag  @ $0251      ;Flag: BAM changed, drive 0
+d1BamChangFlag  @ $0252      ;Flag: BAM changed, drive 1
+dirEntryFndFlag @ $0253      ;Flag for directory entry found
+dirOutputFlag   @ $0254      ;Flag for directory output
+cmdWaitFlag     @ $0255      ;Flag: Waiting for command
+lastUsedBuf     @ $0257      ;Last used buffer
+recordLen       @ $0258      ;Record length
+sideSecTrk      @ $0259      ;Track of side sector
+sideSecSec      @ $025a      ;Sector of side sector
+lastWorkBufs    @ $025b 5    ;Last work (buffers)
+dirSecBufs      @ $0260 5    ;Directory sector (buffers)
+fileDirIdxBufs  @ $0266 5    ;File's index in directory (buffers)
+ledFlashCnt     @ $026c      ;Counter for LED flash
+ledFlashMask    @ $026d      ;Error LED mask for flashing
+driveForLastPrg @ $026e      ;Drive for last program
+secForLastPrg   @ $026f      ;sector for last program
+writeLindx      @ $0270      ;Write LINDX
+readLindx       @ $0271      ;Read LINDX
+inputLineLen    @ $0274      ;Length of input line
+charToProcess   @ $0275      ;Char to interpret
+endOfCmdBufFN   @ $0276      ;Index: End of filename in command buffer
+numOfFNs        @ $0278      ;Number of filenames
+tblPtrFNs       @ $027a 6    ;Pointer table: filenames
+fileTrk         @ $0280      ;Track of a file
+fileSec         @ $0285      ;Sector of a file
+patternFlag     @ $028a      ;Flag: wild cards
+fileStrmImage   @ $028b      ;File stream image
+numDriveSrches  @ $028c      ;Number of drives to look for
+driveSearchFlag @ $028d      ;Flag: Looking for drive
+driveWthLastErr @ $028e      ;drive with last write/open error, used as default drive
+foundInDirFlag  @ $028f      ;Flag: Found in directory
+dirSec          @ $0290      ;Directory sector
+sec1stAvailFile @ $0291      ;Sector for first available file
+idx1stAvailFile @ $0292      ;Index (in directory) for first available file
+zeroIfLastBlk   @ $0293      ;=0 if last block
+curBufIndex     @ $0294      ;Current buffer-index
+filesCnt        @ $0295      ;Counter: Files
+typeFlag        @ $0296      ;Flag: Name matching wild cards
+fileMode        @ $0297      ;Active file mode (R or W)
+jobReturnFlag   @ $0298      ;Flag: job return
+recoveryPtr     @ $0299 2    ;Pointer for recovery
+totalTrkOffset  @ $029a      ;Total tracks offset
+lastBamUpdtPtr  @ $029b 2    ;Pointer: BAM last update
+bamImgTrackNum  @ $029d 2    ;Track # of BAM image (drive 0/1)
+bamImg          @ $02a1 16   ;BAM image
+dirOutputBuf    @ $02b1 36   ;Buffer for directory output
+errMsgBuf       @ $02d5 36   ;Buffer for error message
+noWriteBamFlag  @ $02f9      ;Flag: Don't write BAM
+numFreeBlksLo   @ $02fa 2    ;Number of free blocks, lo for drives 0 and 1
+numFreeBlksHi   @ $02fc 2    ;Number of free blocks, hi for drives 0 and 1
+stepperPhase    @ $02fe 2    ;Current phase of head stepper motor
+buffer0         @ $0300 256  ;Buffer 0
+buffer1         @ $0400 256  ;Buffer 1
+buffer2         @ $0500 256  ;Buffer 2
+buffer3         @ $0600 256  ;Buffer 3
+buffer4         @ $0700 256  ;Buffer 4

--- a/SourceGen/RuntimeData/Commodore/1541-ROM.sym65
+++ b/SourceGen/RuntimeData/Commodore/1541-ROM.sym65
@@ -1,0 +1,309 @@
+; See the LICENSE file for distribution terms (Apache 2.0).
+;
+; Parts adapted from multiple sources:
+;
+; - Commodore 1541 / OC-118 Disk Drive Memory Map (v1.3, Jan 18, 1995)
+;   https://ist.uwaterloo.ca/~schepers/MJK/ascii/1541map.txt
+;
+; - Commodore 1541 drive memory map
+;   https://sta.c64.org/cbm1541mem.html
+;
+; - DOS 2.6 ROM LISTINGS (v1.0, Feb 11, 2000)
+;   http://www.ffd2.com/fridge/docs/1541dis.html
+;
+; - CBM DOS ROM disassembly and memory variables for Commodore 1541 drive
+;   https://g3sl.github.io/c1541rom.html
+
+*SYNOPSIS 1541 ROM and memory-mapped I/O labels
+
+via1PortB       @ $1800      ;VIA1: port B serial bus
+via1PortA       @ $1801      ;VIA1: port A. Read to ack interrupt from ATN IN going high
+via1PortBddr    @ $1802      ;VIA1: port B data direction reg
+via1PortAddr    @ $1803      ;VIA1: port A data direction reg
+via1Timer       @ $1805      ;VIA1: Timer
+via2PortB       @ $1c00      ;VIA2: PB, control port B
+via2PortA       @ $1c01      ;VIA2: PA, port A (data to and from read/write head)
+via2PortBddr    @ $1c02      ;VIA2: CB, data direction port B
+via2PortAddr    @ $1c03      ;VIA2: A, data direction port A
+timerLo         @ $1c04      ;Timer low byte
+timerHi         @ $1c05      ;Timer high byte, write to start timer
+timerStartValLo @ $1c06      ;Timer starting value low byte
+timerStartValHi @ $1c07      ;Timer starting value high byte
+timerCtrl       @ $1c0b      ;Timer control register
+auxCtrl         @ $1c0c      ;Auxiliary control register
+interruptStatus @ $1c0d      ;Interrupt status register
+interruptCtrl   @ $1c0e      ;Interrupt control register                         
+ledOnCurrDrive  @ $c100      ;Turn LED on for current drive
+ledOn           @ $c118      ;Turn LED on
+clrErrors       @ $c123      ;Clear error flags
+prepLedFlash    @ $c12c      ;Prepare for LED flash after error
+interpretCmd    @ $c146      ;Interpret command from computer
+prepError       @ $c194      ;Prepare error msg after executing command
+clrInputBuf     @ $c1bd      ;Erase input buffer
+outErrorMsg     @ $c1c8      ;Output error msg (track and sector 0)
+chkInputLine    @ $c1d1      ;Check input line
+srchInputBuf    @ $c268      ;Search character in input buffer
+chkLineLen      @ $c2b3      ;Check line length
+clrInputFlags   @ $c2dc      ;Clear flags for command input
+prsrvDriveNum   @ $c312      ;Preserve drive number
+searchDriveNum  @ $c33c      ;Search for drive number
+getDriveNum     @ $c368      ;Get drive number
+reserveDriveNum @ $c38f      ;Reverse drive number
+chkFileType     @ $c398      ;Check given file type
+chkDriveNum     @ $c3bd      ;Check given drive number
+verifyDriveNum  @ $c3ca      ;Verify drive number
+searchDir       @ $c44f      ;Search for file in directory
+testInitDrive   @ $c63d      ;Test and initalise drive
+fnInDirBuf      @ $c66e      ;Name of file in directory buffer
+putFnInWorkBuf  @ $c688      ;Copy filename to work buffer
+searchEndOfName @ $c6a6      ;Search for end of name in command
+clrDirOutputBuf @ $c7ac      ;Clear Directory Output Buffer
+hdrWithDiskName @ $c7b7      ;Create header with disk name
+printBlocksFree @ $c806      ;Print 'blocks free.'
+deleteCmd       @ $c823      ;Perform S - Scratch command
+deleteFile      @ $c87d      ;Erase file
+deleteEntry     @ $c8b6      ;Erase dir entry
+formatCmd       @ $c8c6      ;Format disk
+copyCmd         @ $c8f0      ;Perform C - Copy command
+renameCmd       @ $ca88      ;Perform R - Rename command
+presentCmd      @ $cacc      ;Check if file present
+memoryCmd       @ $caf8      ;Perform M - Memory command
+memReadCmd      @ $cb20      ;M-R memory read
+memWriteCmd     @ $cb50      ;M-W memory write
+userCmd         @ $cb5c      ;Perform U - User command
+openDirAccChnl  @ $cb84      ;Open direct access channel, number
+blockCmd        @ $cc1b      ;Perform B - Block/Buffer command
+parseBlkParams  @ $cc6f      ;Get parameters from block commands
+blockFreeCmd    @ $ccf5      ;B-F block free
+blockAllocCmd   @ $cd03      ;B-A block allocate
+readBlockToBuf  @ $cd36      ;Read block to buffer
+getBufByte      @ $cd3c      ;Get byte from buffer
+readBlock       @ $cd42      ;Read block from disk
+blkReadCmd      @ $cd56      ;B-R block read
+blkReadInPlace  @ $cd5f      ;U1, Block read without changing buffer pointer
+blkWriteCmd     @ $cd73      ;B-W block write
+blkWriteInPlace @ $cd97      ;U2, Block write without changing buffer pointer
+blkExecCmd      @ $cda3      ;B-E block execute
+blkPtrCmd       @ $cdbd      ;B-P block pointer
+openChnl        @ $cdd2      ;Open channel
+chkBufNum       @ $cdf2      ;Check buffer number and open channel
+setRelFilePtr   @ $ce0e      ;Set pointer for REL file
+div254          @ $ce6e      ;Divide by 254
+div120          @ $ce71      ;Divide by 120
+eraseWrkMem     @ $ced9      ;Erase work storage
+chgBuf          @ $cf8c      ;Change buffer
+writeInBuf      @ $cf9b      ;Write data in buffer
+writeByteInBuf  @ $cff1      ;Write data byte in buffer
+initCmd         @ $d005      ;Perform I - Initalise command
+readBam         @ $d00e      ;Read BAM from disk
+loadBam         @ $d042      ;Load BAM
+calcFree        @ $d075      ;Calculate blocks free
+readBlock       @ $d0c3      ;Read block
+writeBlock      @ $d0c7      ;Write block
+openReadChnl    @ $d0eb      ;Open channel for reading
+openWriteChnl   @ $d107      ;Open channel for writing
+checkForRel     @ $d125      ;Check for file type REL
+getBufChnlNums  @ $d12f      ;Get buffer and channel numbers
+getByteFromBuf  @ $d137      ;Get a byte from buffer
+getByteNextBlk  @ $d156      ;Get byte and read next block
+writeToBufBlk   @ $d19d      ;Write byte in buffer and block
+incBufPtrs      @ $d1c6      ;Increment buffer pointer
+getDriveNum     @ $d1d3      ;Get drive number
+findWChnlBuf    @ $d1df      ;Find write channel and buffer
+findRChnlBuf    @ $d1e2      ;Find read channel and buffer
+closeChnl       @ $d227      ;Close channel
+freeBuf         @ $d25a      ;Free buffer
+findBuf         @ $d28e      ;Find buffer
+closeAllChnls   @ $d307      ;Close all channels
+closeAllDChnls  @ $d313      ;Close all channels of other drives
+findChnlAlloc   @ $d37f      ;Find channel and allocate
+getByteOutput   @ $d39b      ;Get byte for output
+readNextBlk     @ $d44d      ;Read next block
+readBlk         @ $d460      ;Read block
+writeBlk        @ $d464      ;Write block
+allocBufandRead @ $d475      ;Allocate buffer and read block
+allocBlk        @ $d486      ;Allocate new block
+writeDirBlk     @ $d48d      ;Write dir block
+setBufPtr       @ $d4c8      ;Set buffer pointer
+closeIntChnl    @ $d4da      ;Close internal channel
+setBufPtr2      @ $d4e8      ;Set buffer pointer
+getByteFromBuf2 @ $d4f6      ;Get byte from buffer
+chkTSnums       @ $d506      ;Check track and sector numbers
+getTSForJob     @ $d552      ;Get track and sector numbers for current job
+chkValidTSNums  @ $d55f      ;Check for vaild track and sector numbers
+errorDosMismtch @ $d572      ;DOS mismatch error
+readBlk2        @ $d586      ;Read block
+writeBlk2       @ $d58a      ;Write block
+verifyExe       @ $d599      ;Verify execution
+verifyExeNoWait @ $d5a6      ;Verify execution (without wait)
+attempts        @ $d5c6      ;Additional attempts for read errors
+moveHeadHalfTrk @ $d676      ;Move head by half a track
+moveHeadOneTrk  @ $d693      ;Move head one track in or out
+multiAttemptCmd @ $d6a6      ;Attempt command execution multiple times
+parmsToCtrl     @ $d6d0      ;Transmit param to disk controller
+enterFileInDir  @ $d6e4      ;Enter file in dir
+open            @ $d7b4      ;OPEN command, secondary addr 15
+checkAstr       @ $d7c7      ;Check '*' Last file
+checkDolr       @ $d7f3      ;Check '$' Directory
+checkHash       @ $d815      ;Check '#' Channel
+openOverwrite   @ $d8f5      ;Open a file with overwriting (@)
+openRead        @ $d9a0      ;Open file for reading
+openWrite       @ $d9e3      ;Open file for writing
+chkTypetrl      @ $da09      ;Check file type and control mode
+prepAppend      @ $da2a      ;Preparation for append
+openDir         @ $da55      ;Open directory
+closeRoutine    @ $dac0      ;Close routine
+closeFile       @ $db02      ;Close file
+writeLastBlk    @ $db62      ;Write last block
+dirEntry        @ $dba5      ;Directory entry
+readBlkAllocBuf @ $dc46      ;Read block, allocate buffer
+resetPtr        @ $dcb6      ;Reset pointer
+makeNewBlk      @ $dcda      ;Construct a new block
+writeSideSecBlk @ $dd8d      ;Write byte in side-sector block
+verifyWriteCmd  @ $ddab      ;Verify command code for writing
+writeRelBlk     @ $ddf1      ;Write a block of a REL file
+writeForNextTrk @ $ddfd      ;Write bytes for following track
+getTSnums       @ $de0c      ;Get following track and sector numbers
+folTrkLastBlk   @ $de19      ;Following track for last block
+zeroBufPtr      @ $de2b      ;buffer pointer to zero
+getTSnums2      @ $de3b      ;Get track and sector
+getTSfromBuf    @ $de95      ;Get following track and sector from buffer
+copyBuf         @ $dea5      ;Copy buffer contents
+eraseBuf        @ $dec1      ;Erase buffer Y
+getSideSecNum   @ $ded2      ;Get side-sector number
+setBufPtrToSS   @ $dedc      ;Set buffer pointer to side-sector
+getSSandBufPtr  @ $def8      ;Get side sector and buffer pointer
+readSS          @ $df1b      ;Read side-sector
+writeSS         @ $df21      ;Write side-sector
+setBufInSS      @ $df45      ;Set buffer pointer in side-sector
+blocksInRelFile @ $df4c      ;Calculate number of blocks in a REL file
+verifySSinBuf   @ $df66      ;Verify side-sector in buffer
+getBufNum       @ $df93      ;Get buffer number
+nextRecInRel    @ $dfd0      ;Get next record in REL file
+writeBlkGetNext @ $e03c      ;Write block and read next block
+writeByteInRec  @ $e07c      ;Write a byte in a record
+writeByteInRel  @ $e0ab      ;Write byte in REL file
+zeroFillRec     @ $e0f3      ;Fill record with 0s
+writeBufNumTbl  @ $e105      ;Write buffer number in table
+getByteFromRel  @ $e120      ;Get byte from REL file
+getLastSS       @ $e1cb      ;Get last side-sector
+positionCmd     @ $e207      ;Perform P - Position command
+blksToRecords   @ $e2e2      ;Divide data blocks into records
+prtToNextRec    @ $e304      ;Set pointer to next record
+expandSS        @ $e31c      ;Expand side-sector
+writeSSallocNxt @ $e44e      ;Write side-sector and allocate new
+prepErrNumMsg   @ $e60a      ;Prepare error number and message
+errorMsgToBuf   @ $e645      ;Print error message into error buffer
+talk3           @ $e680      ;TALK
+listen          @ $e688      ;LISTEN
+binToPetscii    @ $e69b      ;Convert BIN to petscii (error message buffer)
+bcdToPetscii    @ $e6ab      ;Convert BCD to petscii (error message buffer)
+writeOK         @ $e6bc      ;Write OK in buffer
+trk0ErrorToBuf  @ $e6c1      ;Print error on track 00,00 to error buffer
+curTrkErrToBuf  @ $e6c7      ;Print error on current track to error buffer
+errMsgToBuf     @ $e706      ;Write error message string to buffer
+tokenIntoBuf    @ $e754      ;Get character and in buffer
+getErrMsgChar   @ $e767      ;Get a char of the error message
+incPtr          @ $e775      ;Increment pointer
+usrExecCmd      @ $e7a3      ;Perform & - USR file execute command
+genChecksum     @ $e84b      ;Generate checksum
+serialIrq       @ $e853      ;IRQ routine for serial bus
+serialService   @ $e85b      ;Service the serial bus
+serialSend      @ $e909      ;Send data
+serialDataOutLo @ $e99c      ;DATA OUT lo
+serialDataOutHi @ $e9a5      ;DATA OUT hi
+serialClkOutHi  @ $e9ae      ;CLOCK OUT hi
+serialClkOutLo  @ $e9b7      ;CLOCK OUT lo
+readIEEE        @ $e9c0      ;Read IEEE port
+getByteFromBus  @ $e9c9      ;Get data byte from bus
+getByteWithEOI  @ $e9f2      ;Accept byte with EOI
+acceptData      @ $ea2e      ;Accept data from serial bus
+testATN         @ $ea59      ;Test for ATN
+ledFlash        @ $ea6e      ;Flash LED for hardware defects, self-test
+reset           @ $eaa0      ;Power-up RESET routine
+wait            @ $ebff      ;Wait loop
+loadDir         @ $ec9e      ;Load dir
+transmitDirLine @ $ed59      ;Transmit dir line
+getByteFromBuf3 @ $ed67      ;Get byte from buffer
+validateCmd     @ $ed84      ;Perform V - Validate command
+bamAlloc        @ $ede5      ;Allocate file blocks in BAM
+formatCmd2      @ $ee0d      ;Perform N - New (Format) command
+createBAM       @ $eeb7      ;Create BAM
+writeBAM        @ $eef4      ;Write BAM if needed
+setBAMptr       @ $ef3a      ;Set buffer pointer for BAM
+getDirBlksFree  @ $ef4d      ;Get number of free blocks for dir
+markBlkFree     @ $ef5c      ;Mark block as free
+markBAMchanges  @ $ef88      ;Set flag for BAM changed
+markBlkAlloc    @ $ef90      ;Mark block as allocated
+delBAMsecBit    @ $efcf      ;Erase bit for sector in BAM entry
+updateBAM       @ $eff1      ;Write BAM after change
+delBAMbuf       @ $f005      ;Erase BAM buffer
+clearBAM        @ $f0d1      ;Crear BAM
+getBAMbufNum    @ $f10f      ;Get buffer number for BAM
+bamBufNum       @ $f119      ;Buffer number for BAM
+findFreeBlkAloc @ $f11e      ;Find and allocate free block
+findFreeSecAloc @ $f1a9      ;Find free sector and allocate
+findFreeSectors @ $f1fa      ;Find free sectors in current track
+verFreeBAMblks  @ $f220      ;Verify number of free blocks in BAM
+numSecsPerTrk   @ $f24b      ;Establish number of sectors per track
+initCtrl        @ $f259      ;Initialise disk controller
+irqCtrl         @ $f2b0      ;IRQ routine for disk controller
+headTransport   @ $f2f9      ;Head transport
+execInBuf       @ $f36e      ;Execute program in buffer
+bump            @ $f37c      ;Bump, find track 1 (head at stop)
+initPtrInBuf    @ $f393      ;Initialise pointer in buffer
+readBlkHdr      @ $f3b1      ;Read block header, verify ID
+prsrvBlkHdr     @ $f410      ;Preserve block header
+okInQueue       @ $f418      ;Work Return value $01 (OK) into queue
+error0bInQueue  @ $f41b      ;Work Return value $0b (READ ERROR) into queue
+error09InQueue  @ $f41e      ;Work Return value $09 (READ ERROR) into queue
+optimizeJob     @ $f423      ;Job optimisation
+readSec         @ $f4d1      ;Read sector
+findBlkStart    @ $f50a      ;Find start of data block
+readBlkHdr2     @ $f510      ;Read block header
+waitSync        @ $f556      ;Wait for SYNC
+writeBlk3       @ $f575      ;Write data block to disk
+calcBufParity   @ $f5e9      ;Calculate parity for data buffer
+gcrToBin        @ $f5f2      ;Convert buffer of GCR data into binary
+findSec         @ $f6ca      ;Command code for find sector
+bytesToGcrBytes @ $f6d0      ;Convert 4 binary bytes to 5 GCR bytes
+gcrTable        @ $f77f 16   ;GCR (5-bit) nybble table
+gcrBytesToBytes @ $f7e6      ;Convert 5 GCR bytes to 4 binary bytes
+tblGCRToBinHi   @ $f8a0 64   ;Conversion table GCR to binary - high nybble
+tblGCRToBinLo   @ $f8c0 64   ;Conversion table GCR to binary - low nybble
+decod69GcrBytes @ $f8e0      ;Decode 69 GCR bytes
+blkHdrToGcr     @ $f934      ;Convert block header to GCR code
+errEntry        @ $f969      ;Error entry disk controller
+motorOn         @ $f97e      ;Turn drive motor on
+motorOff        @ $f98f      ;Turn drive motor off
+jobLoop         @ $f99c      ;Job loop disk controller
+moveHeadNextTrk @ $fa05      ;Move head to next track
+calNumSteps     @ $fa1c      ;Calculate number of head steps
+nudgeStepper    @ $fa3b      ;Move stepper motor short distance
+loadHead        @ $fa4e      ;Load head
+prepFastHeadMov @ $fa7b      ;Prepare fast head movement
+fastHeadMov     @ $fa97      ;Fast head movement
+prepSlowHeadMov @ $faa5      ;Prepare slow head movement
+formatRoutine   @ $fac7      ;Formatting
+writeSyncs      @ $fda3      ;Write SYNC 10240 times, erase track
+writeByteFill   @ $fdc3      ;Read/write ($621/$622) times
+formatErrRetry  @ $fdd3      ;Attempt counter for formatting
+cpyOvflwDataBuf @ $fdf5      ;Copy data from overflow buffer
+switchToRead    @ $fe00      ;Switch to reading
+write55Fill     @ $fe0e      ;Write $55 10240 times
+buf0HdrToGcr    @ $fe30      ;Convert header in buffer 0 to GCR code
+irdMainSystem   @ $fe67      ;Interrupt routine
+jmpToVNMI       @ $fee7      ;From UI command $eb22, to reset
+diagPatch       @ $feea      ;Patch for diagnostic routine from $ea7a
+serialBusDelay  @ $fef3      ;Delay loop for serial bus in 1541 mode, from $e97d
+serialOutPatch  @ $fefb      ;Patch for data output to serial bus, from $e980
+switch1540_1541 @ $ff01 2    ;U9 vector, switch 1540/1541
+resetPatch      @ $ff10      ;Patch for reset routine, from $eaa4
+listenPatch     @ $ff20      ;Patch for listen to serial bus, from $e9dc
+vecFormat       @ $ffe6 2    ;vector for format
+vecOff          @ $ffe8 2    ;vector for $f98f
+vecUblkkrd      @ $ffea 2    ;vector for $cd5f
+vecUblkwt       @ $ffec 2    ;vector for $cd97
+vecNMI          @ $fffa 2    ;vector to $ff01
+vecInit         @ $fffc 2    ;vector to $eaa0
+vecIrq          @ $fffe 2    ;vector to $fe67

--- a/SourceGen/RuntimeData/Commodore/C64-BASIC-RAM-use.sym65
+++ b/SourceGen/RuntimeData/Commodore/C64-BASIC-RAM-use.sym65
@@ -1,0 +1,88 @@
+; See the LICENSE file for distribution terms (Apache 2.0).
+;
+; Parts adapted from multiple sources:
+;
+; - Project 64, 64MAP10.TXT, June 1996, etext #41
+;   http://unusedino.de/ec64/technical/project64/memory_maps.html
+;
+; - "Mapping the Commodore 64", by Sheldon Leemon
+;   Compute! Publications Inc. (1984), ISBN 0-942386-23-X 
+;   https://archive.org/details/Compute_s_Mapping_the_Commodore_64
+
+*SYNOPSIS RAM locations used by BASIC
+
+ADRAY1          @ $0003 2    ;Vector: Convert FAC to Integer in (A/Y) ($b1aa)
+ADRAY2          @ $0005 2    ;Vector: Convert int in (A/Y) to float in (FAC) ($b391)
+CHARAC          @ $0007      ;Search Character/Temporary Integer during INT
+ENDCHR          @ $0008      ;Flag: Scan for Quote at end of String
+INTEGR          @ $0007      ;Temporary Integer during OR/AND
+TRMPOS          @ $0009      ;Screen Column for last TAB
+VERCK           @ $000a      ;Flag: 0 = Load, 1 = Verify
+COUNT           @ $000b      ;Input Buffer Pointer/Number of Subscripts
+DIMFLG          @ $000c      ;Flag: Default Array dimension
+VALTYP          @ $000d      ;Data type Flag: $00 = Numeric, $FF = String
+INTFLG          @ $000e      ;Data type Flag: $00 = Floating point, $80 = Integer
+GARBFL          @ $000f      ;Flag: DATA scan/List Quote/Garbage collection
+SUBFLG          @ $0010      ;Flag: Subscript reference/User Function call
+INPFLG          @ $0011      ;Input Flag: $00 = INPUT, $40 = GET, $98 = READ
+TANSGN          @ $0012      ;Flag: TAN sign/Comparative result
+CHANNL          @ $0013      ;File number of current Input Device
+LINNUM          @ $0014 2    ;Temporary: Integer value
+TEMPPT          @ $0016      ;Pointer: Temporary String Stack
+LASTPT          @ $0017 2    ;Last temporary String Address
+TEMPST          @ $0019 9    ;Stack for temporary Strings
+INDEX1          @ $0022 2    ;First Utility Pointer
+INDEX2          @ $0024 2    ;Second Utility Pointer
+RESHO           @ $0026 5    ;Floating point product of Multiply and Divide
+TXTTAB          @ $002b 2    ;Pointer: Start of BASIC Text Area ($0801)
+VARTAB          @ $002d 2    ;Pointer: Start of BASIC Variables
+ARYTAB          @ $002f 2    ;Pointer: Start of BASIC Arrays
+STREND          @ $0031 2    ;Pointer: End of BASIC Arrays + 1
+FRETOP          @ $0033 2    ;Pointer: Bottom of String space
+FRESPC          @ $0035 2    ;Utility String Pointer
+MEMSIZ          @ $0037 2    ;Pointer: Highest Address available to BASIC ($a000)
+CURLIN          @ $0039 2    ;Current BASIC Line number
+OLDLIN          @ $003b 2    ;Previous BASIC Line number
+OLDTXT          @ $003d 2    ;Pointer: BASIC Statement for CONT
+DATLIN          @ $003f 2    ;Current DATA Line number
+DATPTR          @ $0041 2    ;Pointer: Used by READ - current DATA Item Address
+INPPTR          @ $0043 2    ;Pointer: Temporary storage of Pointer during INPUT Routine
+VARNAM          @ $0045 2    ;Name of Variable being sought in Variable Table
+VARPNT          @ $0047 2    ;Pointer: to value of (VARNAM) if Int, to descriptor if Str
+FORPNT          @ $0049 2    ;Pointer: Index Variable for FOR/NEXT loop
+VARTXT          @ $004b 2    ;Temporary storage for TXTPTR during READ, INPUT and GET
+OPMASK          @ $004d      ;Mask used during FRMEVL
+TEMPF3          @ $004e 2    ;Temporary storage for FLPT value
+FOUR6           @ $0053      ;Length of String Variable during Garbage collection
+JMPER           @ $0054 3    ;jmp used in Function Evaluation
+TEMPF1          @ $0057 10   ;Temporary storage for FLPT value
+TEMPF2          @ $005c      ;Temporary storage for FLPT value
+FACEXP          @ $0061      ;FAC Exponent
+FACHO           @ $0062 4    ;FAC Mantissa
+FACSGN          @ $0066      ;FAC Sign
+SGNFLG          @ $0067      ;Pointer: Series Evaluation Constant
+BITS            @ $0068      ;Bit Overflow Area during normalisation Routine
+ARGEXP          @ $0069      ;AFAC Exponent
+ARGHO           @ $006a 4    ;AFAC Mantissa
+ARGSGN          @ $006e      ;AFAC Sign
+ARISGN          @ $006f      ;Sign of result of Arithmetic Evaluation
+FACOV           @ $0070      ;FAC low-order rounding
+FBUFPT          @ $0071 2    ;Pointer: Used during CRUNCH/ASCII conversion
+CHRGET          @ $0073      ;Subroutine: Get next Byte of BASIC Text
+CHRGOT          @ $0079      ;Entry to Get same Byte again
+TXTPTR          @ $007a 2    ;Pointer: Current Byte of BASIC Text
+RNDX            @ $008b 5    ;Floating RND Function Seed Value
+BSTACK          @ $013f      ;BASIC Stack Area
+BUF             @ $0200      ;BASIC Input Buffer (Input Line from Screen)
+IERROR          @ $0300 2    ;Vector: BASIC Error ($e38b)
+IMAIN           @ $0302 2    ;Vector: BASIC Input Line ($a483)
+ICRNCH          @ $0304 2    ;Vector: BASIC Tokenise ($a57c)
+IQPLOP          @ $0306 2    ;Vector: BASIC LIST ($a71a)
+IGONE           @ $0308 2    ;Vector: BASIC Character ($a7e4)
+IEVAL           @ $030a 2    ;Vector: BASIC Token ($ae86)
+SAREG           @ $030c      ;Storage for 6510 Accumulator during SYS
+SXREG           @ $030d      ;Storage for 6510 X-Register during SYS
+SYREG           @ $030e      ;Storage for 6510 Y-Register during SYS
+SPREG           @ $030f      ;Storage for 6510 Status Register during SYS
+USRPOK          @ $0310      ;USR Function JMP Instruction ($4c)
+USRADD          @ $0311      ;USR Address ($LB,$MB)

--- a/SourceGen/RuntimeData/Commodore/C64-BASIC-ROM.sym65
+++ b/SourceGen/RuntimeData/Commodore/C64-BASIC-ROM.sym65
@@ -1,0 +1,183 @@
+; See the LICENSE file for distribution terms (Apache 2.0).
+;
+; Parts adapted from multiple sources:
+;
+; - Project 64, 64MAP10.TXT, June 1996, etext #41
+;   http://unusedino.de/ec64/technical/project64/memory_maps.html
+;
+; - PageTable's C64 BASIC & KERNAL ROM Disassembly
+;   https://www.pagetable.com/c64ref/c64disasm/
+;
+; - "Mapping the Commodore 64", by Sheldon Leemon
+;   Compute! Publications Inc. (1984), ISBN 0-942386-23-X 
+;   https://archive.org/details/Compute_s_Mapping_the_Commodore_64
+
+*SYNOPSIS BASIC ROM ($a000-$bfff) labels (functions and vectors)
+
+coldStartVec    @ $a000 2    ;Cold Start Vector
+warmStartVec    @ $a002 2    ;Warm Start Vector
+fndfor          @ $a38a      ;Find FOR/GOSUB Entry on Stack
+bltu            @ $a3b8      ;Open Space in Memory
+getstk          @ $a3fb      ;Check Stack Depth
+reason          @ $a408      ;Check Memory Overlap
+omerr           @ $a435      ;Output ?OUT OF MEMORY Error
+error           @ $a437      ;Error Routine
+errfin          @ $a469      ;Break Entry
+ready           @ $a474      ;Restart BASIC
+main            @ $a480      ;Input & Identify BASIC Line
+main1           @ $a49c      ;Get Line Number & Tokenise Text
+inslin          @ $a4a2      ;Insert BASIC Text
+linkprg         @ $a533      ;Rechain Lines
+inlin           @ $a560      ;Input Line Into Buffer
+crunch          @ $a579      ;Tokenise Input Buffer
+fndlin          @ $a613      ;Search for Line Number
+scrtch          @ $a642      ;Perform new
+clear           @ $a65e      ;Perform clr
+stxpt           @ $a68e      ;Reset TXTPTR
+list            @ $a69c      ;Perform list
+qplop           @ $a717      ;Handle LIST Character
+for             @ $a742      ;Perform for
+newstt          @ $a7ae      ;BASIC Warm Start
+ckeol           @ $a7c4      ;Check End of Program
+gone            @ $a7e1      ;Prepare to execute statement
+gone3           @ $a7ed      ;Perform BASIC Keyword
+restor3         @ $a81d      ;Perform restore
+stop            @ $a82c      ;Perform stop, end, break
+cont            @ $a857      ;Perform cont
+run             @ $a871      ;Perform run
+gosub           @ $a883      ;Perform gosub
+goto            @ $a8a0      ;Perform goto
+return          @ $a8d2      ;Perform return
+data            @ $a8f8      ;Perform data
+datan           @ $a906      ;Search for Next Statement / Line
+if              @ $a928      ;Perform if
+rem             @ $a93b      ;Perform rem
+ongoto          @ $a94b      ;Perform on
+linget          @ $a96b      ;Fetch linnum From BASIC
+let             @ $a9a5      ;Perform let
+putint          @ $a9c4      ;Assign Integer
+ptflpt          @ $a9d6      ;Assign Floating Point
+putstr          @ $a9d9      ;Assign String
+puttim          @ $a9e3      ;Assign TI$
+getspt          @ $aa2c      ;Add Digit to FAC#1
+printn          @ $aa80      ;Perform print#
+cmd             @ $aa86      ;Perform cmd
+strdon          @ $aa9a      ;Print String From Memory
+print           @ $aaa0      ;Perform print
+varop           @ $aab8      ;Output Variable
+crdo            @ $aad7      ;Output CR/LF
+comprt          @ $aae8      ;Handle comma, TAB(, SPC(
+strout          @ $ab1e      ;Output String
+outspc          @ $ab3b      ;Output Format Character
+doagin          @ $ab4d      ;Handle Bad Data
+get             @ $ab7b      ;Perform get
+inputn          @ $aba5      ;Perform input#
+input           @ $abbf      ;Perform input
+bufful          @ $abea      ;Read Input Buffer
+qinlin          @ $abf9      ;Do Input Prompt
+read            @ $ac06      ;Perform read
+rdget           @ $ac35      ;General Purpose Read Routine
+next            @ $ad1e      ;Perform next
+donext          @ $ad61      ;Check Valid Loop
+frmnum          @ $ad8a      ;Confirm Result
+frmevl          @ $ad9e      ;Evaluate Expression in Text
+eval            @ $ae83      ;Evaluate Single Term
+qdot            @ $aead      ;Continue Expression
+parchk          @ $aef1      ;Expression in Brackets
+chkcls          @ $aef7      ;Confirm Character
+synerr          @ $af08      ;Output ?SYNTAX Error
+domin           @ $af0d      ;Set up NOT Function
+rsvvar          @ $af14      ;Identify Reserved Variable
+isvar           @ $af28      ;Search for Variable
+tisasc          @ $af48      ;Convert TI to ASCII String
+isfun           @ $afa7      ;Identify Function Type
+strfun          @ $afb1      ;Evaluate String Function
+numfun          @ $afd1      ;Evaluate Numeric Function
+orop            @ $afe6      ;Perform or, and
+dorel           @ $b016      ;Perform <, =, >
+numrel          @ $b01b      ;Numeric Comparison
+strrel          @ $b02e      ;String Comparison
+dim             @ $b07e      ;Perform dim
+ptrget          @ $b08b      ;Identify Variable
+ordvar          @ $b0e7      ;Locate Ordinary Variable
+notfns          @ $b11d      ;Create New Variable
+notevl          @ $b128      ;Create Variable
+aryget          @ $b194      ;Allocate Array Pointer Space
+facinx          @ $b1aa      ;FAC#1 to Integer in (AC/YR)
+intidx          @ $b1b2      ;Evaluate Text for Integer
+ayint           @ $b1bf      ;FAC#1 to Positive Integer
+isary           @ $b1d1      ;Get Array Parameters
+fndary          @ $b218      ;Find Array
+bserr           @ $b245      ;?BAD SUBSCRIPT/?ILLEGAL QUANTITY
+notfdd          @ $b261      ;Create Array
+inlpn2          @ $b30e      ;Locate Element in Array
+umult           @ $b34c      ;Number of Bytes in Subscript
+fre             @ $b37d      ;Perform fre
+givayf          @ $b391      ;Convert Integer in (AC/YR) to Flpt
+pos             @ $b39e      ;Perform pos
+errdir          @ $b3a6      ;Confirm Program Mode
+getfnm          @ $b3e1      ;Check Syntax of FN
+fndoer          @ $b3f4      ;Perform fn
+strd            @ $b465      ;Perform str$
+strlit          @ $b487      ;Set Up String
+putnw1          @ $b4d5      ;Save String Descriptor
+getspa          @ $b4f4      ;Allocate Space for String
+garbag          @ $b526      ;Garbage Collection
+dvars           @ $b5bd      ;Search for Next String
+grbpas          @ $b606      ;Collect a String
+cat             @ $b63d      ;Concatenate Two Strings
+movins          @ $b67a      ;Store String in High RAM
+frestr          @ $b6a3      ;Perform String Housekeeping
+frefac          @ $b6db      ;Clean Descriptor Stack
+chrd            @ $b6ec      ;Perform chr$
+leftd           @ $b700      ;Perform left$
+rightd          @ $b72c      ;Perform right$
+midd            @ $b737      ;Perform mid$
+pream           @ $b761      ;Pull sTring Parameters
+len             @ $b77c      ;Perform len
+len1            @ $b782      ;Exit String Mode
+asc             @ $b78b      ;Perform asc
+gtbytc          @ $b79b      ;Evaluate Text to 1 Byte in XR
+val             @ $b7ad      ;Perform val
+strval          @ $b7b5      ;Convert ASCII String to Flpt
+getnum          @ $b7eb      ;Get parameters for POKE/WAIT
+getadr          @ $b7f7      ;Convert FAC#1 to Integer in LINNUM
+peek            @ $b80d      ;Perform peek
+poke            @ $b824      ;Perform poke
+wait            @ $b82d      ;Perform wait
+faddh           @ $b849      ;Add 0.5 to FAC#1
+fsub            @ $b850      ;Perform Subtraction
+fadd5           @ $b862      ;Normalise Addition
+fadd            @ $b867      ;Perform Addition
+negfac          @ $b947      ;2's Complement FAC#1
+overr           @ $b97e      ;Output ?OVERFLOW Error
+mulshf          @ $b983      ;Multiply by Zero Byte
+log             @ $b9ea      ;Perform log
+fmult           @ $ba28      ;Perform Multiply
+mulply          @ $ba59      ;Multiply by a Byte
+conupk          @ $ba8c      ;Load FAC#2 From Memory
+muldiv          @ $bab7      ;Test Both Accumulators
+mldvex          @ $bad4      ;Overflow / Underflow
+mul10           @ $bae2      ;Multiply FAC#1 by 10
+div10           @ $bafe      ;Divide FAC#1 by 10
+fdiv            @ $bb07      ;Divide FAC#2 by Flpt at (AC/YR)
+fdivt           @ $bb0f      ;Divide FAC#2 by FAC#1
+movfm           @ $bba2      ;Load FAC#1 From Memory
+mov2f           @ $bbc7      ;Store FAC#1 in Memory
+movfa           @ $bbfc      ;Copy FAC#2 into FAC#1
+movaf           @ $bc0c      ;Copy FAC#1 into FAC#2
+round           @ $bc1b      ;Round FAC#1
+sign            @ $bc2b      ;Check Sign of FAC#1
+sgn             @ $bc39      ;Perform sgn
+abs             @ $bc58      ;Perform abs
+fcomp           @ $bc5b      ;Compare FAC#1 With Memory
+qint            @ $bc9b      ;Convert FAC#1 to Integer
+int             @ $bccc      ;Perform int
+fin             @ $bcf3      ;Convert ASCII String to a Number in FAC#1
+inprt           @ $bdc2      ;Output 'IN' and Line Number
+fout            @ $bddd      ;Convert FAC#1 to ASCII String
+foutim          @ $be68      ;Convert TI to String
+sqr             @ $bf71      ;Perform sqr
+fpwrt           @ $bf7b      ;Perform power ($)
+negop           @ $bfb4      ;Negate FAC#1
+exp             @ $bfed      ;Perform exp (continued in KERNAL)

--- a/SourceGen/RuntimeData/Commodore/C64-IO.sym65
+++ b/SourceGen/RuntimeData/Commodore/C64-IO.sym65
@@ -11,114 +11,114 @@
 
 *SYNOPSIS Commodore 64 memory-mapped I/O addresses (and color ram)
 
-D6510           @ $0000     ;6510 I/O Data Direction Register
-R6510           @ $0001     ;ROM/IO Banking and Cassette I/O
-SPOX            @ $D000     ;Sprite 0 X Pos
-SPOY            @ $D001     ;Sprite 0 Y Pos
-SP1X            @ $D002     ;Sprite 1 X Pos
-SP1Y            @ $D003     ;Sprite 1 Y Pos
-SP2X            @ $D004     ;Sprite 2 X Pos
-SP2Y            @ $D005     ;Sprite 2 Y Pos
-SP3X            @ $D006     ;Sprite 3 X Pos
-SP3Y            @ $D007     ;Sprite 3 Y Pos
-SP4X            @ $D008     ;Sprite 4 X Pos
-SP4Y            @ $D009     ;Sprite 4 Y Pos
-SP5X            @ $D00A     ;Sprite 5 X Pos
-SP5Y            @ $D00B     ;Sprite 5 Y Pos
-SP6X            @ $D00C     ;Sprite 6 X Pos
-SP6Y            @ $D00D     ;Sprite 6 Y Pos
-SP7X            @ $D00E     ;Sprite 7 X Pos
-SP7Y            @ $D00F     ;Sprite 7 Y Pos
-MSIGX           @ $D010     ;Sprites 0-7 X Pos 9th bit
-SCROLY          @ $D011     ;VIC Control Register
-RASTER          @ $D012     ;Read Raster / Write Raster Value for Compare
-LPENX           @ $D013     ;Light Pen/Gun Latch X Pos (divided by 2)
-LPENY           @ $D014     ;Light Pen/Gun Latch Y Pos
-SPENA           @ $D015     ;Sprites 0-7 display Enable (1 = enable)
-SCROLX          @ $D016     ;VIC Control Register
-YXPAND          @ $D017     ;Sprites 0-7 Expand 2x Vertical
-VMCSB           @ $D018     ;VIC Memory Control Register
-VICIRQ          @ $D019     ;VIC Interrupt Flag Register
-IRQMSK          @ $D01A     ;IRQ Mask Register (1 = Interrupt Enable)
-SPBGPR          @ $D01B     ;Sprite to Background Display Priority
-SPMC            @ $D01C     ;Sprites 0-7 Multi-Color Mode Select
-XXPAND          @ $D01D     ;Sprites 0-7 Expand 2x Horizontal
-SPSPCL          @ $D01E     ;Sprite to Sprite Collision Detect
-SPBGCL          @ $D01F     ;Sprite to Background Collision Detect
-EXTCOL          @ $D020     ;Border Color
-BGCOL0          @ $D021     ;Background Color 0 (screen color)
-BGCOL1          @ $D022     ;Background Color 1
-BGCOL2          @ $D023     ;Background Color 2
-BGCOL3          @ $D024     ;Background Color 3
-SPMC0           @ $D025     ;Sprite Multi-Color Register 0
-SPMC1           @ $D026     ;Sprite Multi-Color Register 1
-SP0CL           @ $D027     ;Sprite 0 Color
-SP1CL           @ $D028     ;Sprite 1 Color
-SP2CL           @ $D029     ;Sprite 2 Color
-SP3CL           @ $D02A     ;Sprite 3 Color
-SP4CL           @ $D02B     ;Sprite 4 Color
-SP5CL           @ $D02C     ;Sprite 5 Color
-SP6CL           @ $D02D     ;Sprite 6 Color
-SP7CL           @ $D02E     ;Sprite 7 Color
-FRELO1          > $D400     ;Voice 1 Frequency - Low-Byte
-FREHI1          > $D401     ;Voice 1 Frequency - High-Byte
-PWLO1           > $D402     ;Voice 1 Pulse Waveform Width - Low-Byte
-PWHI1           > $D403     ;Voice 1 Pulse Waveform Width - High-Nybble
-VCREG1          > $D404     ;Voice 1 Control Register
-ATDCY1          > $D405     ;Voice 1 Attack / Decay
-SUREL1          > $D406     ;Voice 1 Sustain / Release
-FRELO2          > $D407     ;Voice 2 Frequency - Low-Byte
-FREHI2          > $D408     ;Voice 2 Frequency - High-Byte
-PWLO2           > $D409     ;Voice 2 Pulse Waveform Width - Low-Byte
-PWHI2           > $D40A     ;Voice 2 Pulse Waveform Width - High-Nybble
-VCREG2          > $D40B     ;Voice 2 Control Register
-ATDCY2          > $D40C     ;Voice 2 Attack / Decay
-SUREL2          > $D40D     ;Voice 2 Sustain / Release
-FRELO3          > $D40E     ;Voice 3 Frequency - Low-Byte
-FREHI3          > $D40F     ;Voice 3 Frequency - High-Byte
-PWLO3           > $D410     ;Voice 3 Pulse Waveform Width - Low-Byte
-PWHI3           > $D411     ;Voice 3 Pulse Waveform Width - High-Nybble
-VCREG3          > $D412     ;Voice 3 Control Register
-ATDCY3          > $D413     ;Voice 3 Attack/Decay
-SUREL3          > $D414     ;Voice 3 Sustain / Release
-CUTLO           > $D415     ;Filter Cutoff Frequency Low-Nybble
-CUTHI           > $D416     ;Filter Cutoff Frequency High-Byte
-RESON           > $D417     ;Filter Resonance / Voice Input
-SIGVOL          > $D418     ;Select Filter Mode and Volume
-POTX            > $D419     ;Analog/Digital Converter Game Paddle 1
-POTY            > $D41A     ;Analog/Digital Converter Game Paddle 2
-RANDOM          < $D41B     ;Voice 3 Oscillator output
-ENV3            < $D41C     ;Voice 3 Envelope output
-colorRam        @ $D800     ;Color RAM nybbles ($d800-$dbff)
-CIAPRA          @ $DC00     ;CIA1 Data Port A (Keyboard, Joystick, Paddles, Light-Pen)
-CIAPRB          @ $DC01     ;CIA1 Data Port B (Keyboard, Joysticks, Paddles)
-CIDDRA          @ $DC02     ;CIA1 Data Direction Register - Port A
-CIDDRB          @ $DC03     ;CIA1 Data Direction Register - Port B
-TIMALO          @ $DC04     ;CIA1 Timer A Low-Byte
-TIMAHI          @ $DC05     ;CIA1 Timer A High-Byte
-TIMBLO          @ $DC06     ;CIA1 Timer B Low-Byte
-TIMBHI          @ $DC07     ;CIA1 Timer B High-Byte
-TODTEN          @ $DC08     ;CIA1 Time-of-Day Clock 1/10 Seconds
-TODSEC          @ $DC09     ;CIA1 Time-of-Day Clock Seconds
-TODMIN          @ $DC0A     ;CIA1 Time-of-Day Clock Minutes
-TODHRS          @ $DC0B     ;CIA1 Time-of-Day Clock Hours + AM/PM Flag (Bit 7)
-CIASDR          @ $DC0C     ;CIA1 Synchronous Serial I/O Data Buffer
-CIAICR          @ $DC0D     ;CIA1 CIA Interrupt Control Register
-CIACRA          @ $DC0E     ;CIA1 CIA Control Register A
-CIACRB          @ $DC0F     ;CIA1 CIA Control Register B
-CI2PRA          @ $DD00     ;CIA2 Data Port A (Serial Bus RS-232, VIC Memory Control)
-CI2PRB          @ $DD01     ;CIA2 Data Port B (User Port, RS-232)
-C2DDRA          @ $DD02     ;CIA2 Data Direction Register - Port A
-C2DDRB          @ $DD03     ;CIA2 Data Direction Register - Port B
-TI2ALO          @ $DD04     ;CIA2 Timer A Low-Byte
-TI2AHI          @ $DD05     ;CIA2 Timer A High-Byte
-TI2BLO          @ $DD06     ;CIA2 Timer B Low-Byte
-TI2BHI          @ $DD07     ;CIA2 Timer B High-Byte
-TO2TEN          @ $DD08     ;CIA2 Time-of-Day Clock 1/10 Seconds
-TO2SEC          @ $DD09     ;CIA2 Time-of-Day Clock Seconds
-TO2MIN          @ $DD0A     ;CIA2 Time-of-Day Clock Minutes
-TO2HRS          @ $DD0B     ;CIA2 Time-of-Day Clock Hours + AM/PM Flag (Bit 7)
-CI2SDR          @ $DD0C     ;CIA2 Synchronous Serial I/O Data Buffer
-CI2ICR          @ $DD0D     ;CIA2 CIA Interrupt Control Register
-CI2CRA          @ $DD0E     ;CIA2 CIA Control Register A
-CI2CRB          @ $DD0F     ;CIA2 CIA Control Register B
+D6510           @ $0000      ;6510 I/O Data Direction Register
+R6510           @ $0001      ;ROM/IO Banking and Cassette I/O
+SPOX            @ $D000      ;Sprite 0 X Pos
+SPOY            @ $D001      ;Sprite 0 Y Pos
+SP1X            @ $D002      ;Sprite 1 X Pos
+SP1Y            @ $D003      ;Sprite 1 Y Pos
+SP2X            @ $D004      ;Sprite 2 X Pos
+SP2Y            @ $D005      ;Sprite 2 Y Pos
+SP3X            @ $D006      ;Sprite 3 X Pos
+SP3Y            @ $D007      ;Sprite 3 Y Pos
+SP4X            @ $D008      ;Sprite 4 X Pos
+SP4Y            @ $D009      ;Sprite 4 Y Pos
+SP5X            @ $D00A      ;Sprite 5 X Pos
+SP5Y            @ $D00B      ;Sprite 5 Y Pos
+SP6X            @ $D00C      ;Sprite 6 X Pos
+SP6Y            @ $D00D      ;Sprite 6 Y Pos
+SP7X            @ $D00E      ;Sprite 7 X Pos
+SP7Y            @ $D00F      ;Sprite 7 Y Pos
+MSIGX           @ $D010      ;Sprites 0-7 X Pos 9th bit
+SCROLY          @ $D011      ;VIC Control Register
+RASTER          @ $D012      ;Read Raster / Write Raster Value for Compare
+LPENX           @ $D013      ;Light Pen/Gun Latch X Pos (divided by 2)
+LPENY           @ $D014      ;Light Pen/Gun Latch Y Pos
+SPENA           @ $D015      ;Sprites 0-7 display Enable (1 = enable)
+SCROLX          @ $D016      ;VIC Control Register
+YXPAND          @ $D017      ;Sprites 0-7 Expand 2x Vertical
+VMCSB           @ $D018      ;VIC Memory Control Register
+VICIRQ          @ $D019      ;VIC Interrupt Flag Register
+IRQMSK          @ $D01A      ;IRQ Mask Register (1 = Interrupt Enable)
+SPBGPR          @ $D01B      ;Sprite to Background Display Priority
+SPMC            @ $D01C      ;Sprites 0-7 Multi-Color Mode Select
+XXPAND          @ $D01D      ;Sprites 0-7 Expand 2x Horizontal
+SPSPCL          @ $D01E      ;Sprite to Sprite Collision Detect
+SPBGCL          @ $D01F      ;Sprite to Background Collision Detect
+EXTCOL          @ $D020      ;Border Color
+BGCOL0          @ $D021      ;Background Color 0 (screen color)
+BGCOL1          @ $D022      ;Background Color 1
+BGCOL2          @ $D023      ;Background Color 2
+BGCOL3          @ $D024      ;Background Color 3
+SPMC0           @ $D025      ;Sprite Multi-Color Register 0
+SPMC1           @ $D026      ;Sprite Multi-Color Register 1
+SP0CL           @ $D027      ;Sprite 0 Color
+SP1CL           @ $D028      ;Sprite 1 Color
+SP2CL           @ $D029      ;Sprite 2 Color
+SP3CL           @ $D02A      ;Sprite 3 Color
+SP4CL           @ $D02B      ;Sprite 4 Color
+SP5CL           @ $D02C      ;Sprite 5 Color
+SP6CL           @ $D02D      ;Sprite 6 Color
+SP7CL           @ $D02E      ;Sprite 7 Color
+FRELO1          > $D400      ;Voice 1 Frequency - Low-Byte
+FREHI1          > $D401      ;Voice 1 Frequency - High-Byte
+PWLO1           > $D402      ;Voice 1 Pulse Waveform Width - Low-Byte
+PWHI1           > $D403      ;Voice 1 Pulse Waveform Width - High-Nybble
+VCREG1          > $D404      ;Voice 1 Control Register
+ATDCY1          > $D405      ;Voice 1 Attack / Decay
+SUREL1          > $D406      ;Voice 1 Sustain / Release
+FRELO2          > $D407      ;Voice 2 Frequency - Low-Byte
+FREHI2          > $D408      ;Voice 2 Frequency - High-Byte
+PWLO2           > $D409      ;Voice 2 Pulse Waveform Width - Low-Byte
+PWHI2           > $D40A      ;Voice 2 Pulse Waveform Width - High-Nybble
+VCREG2          > $D40B      ;Voice 2 Control Register
+ATDCY2          > $D40C      ;Voice 2 Attack / Decay
+SUREL2          > $D40D      ;Voice 2 Sustain / Release
+FRELO3          > $D40E      ;Voice 3 Frequency - Low-Byte
+FREHI3          > $D40F      ;Voice 3 Frequency - High-Byte
+PWLO3           > $D410      ;Voice 3 Pulse Waveform Width - Low-Byte
+PWHI3           > $D411      ;Voice 3 Pulse Waveform Width - High-Nybble
+VCREG3          > $D412      ;Voice 3 Control Register
+ATDCY3          > $D413      ;Voice 3 Attack/Decay
+SUREL3          > $D414      ;Voice 3 Sustain / Release
+CUTLO           > $D415      ;Filter Cutoff Frequency Low-Nybble
+CUTHI           > $D416      ;Filter Cutoff Frequency High-Byte
+RESON           > $D417      ;Filter Resonance / Voice Input
+SIGVOL          > $D418      ;Select Filter Mode and Volume
+POTX            > $D419      ;Analog/Digital Converter Game Paddle 1
+POTY            > $D41A      ;Analog/Digital Converter Game Paddle 2
+RANDOM          < $D41B      ;Voice 3 Oscillator output
+ENV3            < $D41C      ;Voice 3 Envelope output
+colorRam        @ $D800 1024 ;Color RAM nybbles ($d800-$dbff)
+CIAPRA          @ $DC00      ;CIA1 Data Port A (Keyboard, Joystick, Paddles, Light-Pen)
+CIAPRB          @ $DC01      ;CIA1 Data Port B (Keyboard, Joysticks, Paddles)
+CIDDRA          @ $DC02      ;CIA1 Data Direction Register - Port A
+CIDDRB          @ $DC03      ;CIA1 Data Direction Register - Port B
+TIMALO          @ $DC04      ;CIA1 Timer A Low-Byte
+TIMAHI          @ $DC05      ;CIA1 Timer A High-Byte
+TIMBLO          @ $DC06      ;CIA1 Timer B Low-Byte
+TIMBHI          @ $DC07      ;CIA1 Timer B High-Byte
+TODTEN          @ $DC08      ;CIA1 Time-of-Day Clock 1/10 Seconds
+TODSEC          @ $DC09      ;CIA1 Time-of-Day Clock Seconds
+TODMIN          @ $DC0A      ;CIA1 Time-of-Day Clock Minutes
+TODHRS          @ $DC0B      ;CIA1 Time-of-Day Clock Hours + AM/PM Flag (Bit 7)
+CIASDR          @ $DC0C      ;CIA1 Synchronous Serial I/O Data Buffer
+CIAICR          @ $DC0D      ;CIA1 CIA Interrupt Control Register
+CIACRA          @ $DC0E      ;CIA1 CIA Control Register A
+CIACRB          @ $DC0F      ;CIA1 CIA Control Register B
+CI2PRA          @ $DD00      ;CIA2 Data Port A (Serial Bus RS-232, VIC Memory Control)
+CI2PRB          @ $DD01      ;CIA2 Data Port B (User Port, RS-232)
+C2DDRA          @ $DD02      ;CIA2 Data Direction Register - Port A
+C2DDRB          @ $DD03      ;CIA2 Data Direction Register - Port B
+TI2ALO          @ $DD04      ;CIA2 Timer A Low-Byte
+TI2AHI          @ $DD05      ;CIA2 Timer A High-Byte
+TI2BLO          @ $DD06      ;CIA2 Timer B Low-Byte
+TI2BHI          @ $DD07      ;CIA2 Timer B High-Byte
+TO2TEN          @ $DD08      ;CIA2 Time-of-Day Clock 1/10 Seconds
+TO2SEC          @ $DD09      ;CIA2 Time-of-Day Clock Seconds
+TO2MIN          @ $DD0A      ;CIA2 Time-of-Day Clock Minutes
+TO2HRS          @ $DD0B      ;CIA2 Time-of-Day Clock Hours + AM/PM Flag (Bit 7)
+CI2SDR          @ $DD0C      ;CIA2 Synchronous Serial I/O Data Buffer
+CI2ICR          @ $DD0D      ;CIA2 CIA Interrupt Control Register
+CI2CRA          @ $DD0E      ;CIA2 CIA Control Register A
+CI2CRB          @ $DD0F      ;CIA2 CIA Control Register B

--- a/SourceGen/RuntimeData/Commodore/C64-Kernal-RAM-use.sym65
+++ b/SourceGen/RuntimeData/Commodore/C64-Kernal-RAM-use.sym65
@@ -1,0 +1,139 @@
+; See the LICENSE file for distribution terms (Apache 2.0).
+;
+; Parts adapted from multiple sources:
+;
+; - Project 64, 64MAP10.TXT, June 1996, etext #41
+;   http://unusedino.de/ec64/technical/project64/memory_maps.html
+;
+; - "Mapping the Commodore 64", by Sheldon Leemon
+;   Compute! Publications Inc. (1984), ISBN 0-942386-23-X 
+;   https://archive.org/details/Compute_s_Mapping_the_Commodore_64
+
+*SYNOPSIS RAM locations used by the KERNAL
+
+STATUS          @ $0090      ;Kernal I/O Status Word ST
+STKEY           @ $0091      ;Flag: $7f = STOP key
+SVXT            @ $0092      ;Timing Constant for Tape
+VERCKK          @ $0093      ;Flag: 0 = Load, 1 = Verify
+C3PO            @ $0094      ;Flag: Serial Bus - Output Character buffered
+BSOUR           @ $0095      ;Buffered Character for Serial Bus
+SYNO            @ $0096      ;Cassette Sync. number
+TEMPX           @ $0097      ;Temporary storage of X Register during CHRIN
+TEMPY           @ $0097      ;Temporary storage of Y Register during RS232 fetch
+LDTND           @ $0098      ;Number of Open Files/Index to File Table
+DFLTN           @ $0099      ;Default Input Device (0)
+DFLTO           @ $009a      ;Default Output Device (3)
+PRTY            @ $009b      ;Parity of Byte Output to Tape
+DPSW            @ $009c      ;Flag: Byte received from Tape
+MSGFLG          @ $009d      ;Set error message mode
+FNMIDX          @ $009e      ;Index to Cassette File name/Header ID for Tape write
+PTR1            @ $009e      ;Tape Error log pass 1
+PTR2            @ $009f      ;Tape Error log pass 2
+TIME            @ $00a0      ;Real-time jiffy Clock, Update Routine: UDTIMK ($f69b)
+TSFCNT          @ $00a3      ;Bit Counter Tape Read or Write/Serial Bus
+TBTCNT          @ $00a4      ;Pulse Counter Tape Read or Write/Serial Bus shift Counter
+CNTDN           @ $00a5      ;Tape Synchronising count down
+BUFPNT          @ $00a6 2    ;Pointer: Tape I/O buffer
+INBIT           @ $00a7      ;RS232 temporary for received Bit/Tape
+BITC1           @ $00a8      ;RS232 Input Bit count/Tape temporary
+RINONE          @ $00a9      ;RS232 Flag: Start Bit check/Tape temporary
+RIDATA          @ $00aa      ;RS232 Input Byte Buffer/Tape temporary
+RIPRTY          @ $00ab      ;RS232 Input parity/Tape temporary
+SAL             @ $00ac 2    ;Pointer: Tape Buffer/Screen scrolling
+EAL             @ $00ae      ;Tape End Address/End of Program
+CMPO            @ $00b0      ;Tape timing Constants
+TAPE1           @ $00b2 2    ;Pointer: Start Address of Tape Buffer ($033c)
+BITTS           @ $00b4      ;RS232 Write bit count/Tape Read timing Flag
+NXTBIT          @ $00b5      ;RS232 Next Bit to send/Tape Read - End of Tape
+RODATA          @ $00b6      ;RS232 Output Byte Buffer/Tape Read Error Flag
+FNLEN           @ $00b7      ;Number of Characters in Filename
+LA              @ $00b8      ;Current File - Logical File number
+SA              @ $00b9      ;Current File - Secondary Address
+FA              @ $00ba      ;Current File - First Address (Device number)
+FNADR           @ $00bb 2    ;Pointer: Current File name Address
+ROPRTY          @ $00bd      ;RS232 Output Parity/Tape Byte to be Input or Output
+FSBLK           @ $00be      ;Tape Input/Output Block count
+MYCH            @ $00bf      ;Serial Word Buffer
+CAS1            @ $00c0      ;Tape Motor Switch
+STAL            @ $00c1      ;Start Address for LOAD and Cassette Write
+MEMUSS          @ $00c3 2    ;Pointer: Type 3 Tape LOAD and general use
+LSTX            @ $00c5      ;Matrix value of last Key pressed; No Key = $40
+NDX             @ $00c6      ;Number of Characters in Keyboard Buffer queue
+RVS             @ $00c7      ;Flag: Reverse On/Off; On = $01, Off = $00
+INDX            @ $00c8 2    ;Pointer: End of Line for Input
+LXSP            @ $00c9      ;Cursor X/Y (Line/Column) position at start of Input
+SFDX            @ $00cb      ;Flag: Print shifted Characters
+BLNSW           @ $00cc      ;Flag: Cursor blink; $00 = Enabled, $01 = Disabled
+BLNCT           @ $00cd      ;Timer: Count down for Cursor blink toggle
+GDBLN           @ $00ce      ;Character under Cursor while Cursor Inverted
+BLNON           @ $00cf      ;Flag: Cursor Status; $00 = Off, $01 = On
+CRSW            @ $00d0      ;Flag: Input from Screen = $03, or Keyboard = $00
+PNT             @ $00d1 2    ;Pointer: Current Screen Line Address
+PNTR            @ $00d3      ;Cursor Column on current Line, including Wrap-round Line, if any
+QTSW            @ $00d4      ;Flag: Editor in Quote Mode; $00 = Not
+LNMX            @ $00d5      ;Current logical Line length: 39 or 79
+TBLX            @ $00d6      ;Current Screen Line number of Cursor
+SCHAR           @ $00d7      ;Screen value of current Input Character/Last Character Output
+INSRT           @ $00d8      ;Count of number of inserts outstanding
+LDTB1           @ $00d9      ;Screen Line link Table/Editor temporaries
+USER            @ $00f3 2    ;Pointer: Current Colour RAM Location
+KEYTAB          @ $00f5 2    ;Vector: Current Keyboard decoding Table ($eb81)
+RIBUF           @ $00f7 2    ;RS232 Input Buffer Pointer
+ROBUF           @ $00f9 2    ;RS232 Output Buffer Pointer
+FREKZP          @ $00fb      ;Free Zero Page space for User Programs
+BASZPT          @ $00ff      ;BASIC temporary Data Area
+ASCWRK          @ $00ff      ;Assembly Area for Floating point to ASCII conversion
+LAT             @ $0259 10   ;Kernal Table: Active logical File numbers
+FAT             @ $0263 10   ;Kernal Table: Active File First Addresses
+SAT             @ $026d 10   ;Kernal Table: Active File Secondary Addresses
+KEYD            @ $0277 10   ;Keyboard Buffer Queue (FIFO)
+MEMSTR          @ $0281 2    ;Pointer: Bottom of Memory for Operating System ($0800)
+MEMSIZ2         @ $0283 2    ;Pointer: Top of Memory for Operating System ($a000)
+TIMOUT          @ $0285      ;Serial IEEE Bus timeout defeat Flag
+COLOR           @ $0286      ;Current Character Colour code
+GDCOL           @ $0287      ;Background Colour under Cursor
+HIBASE          @ $0288      ;High Byte of Screen Memory Address ($04)
+XMAX            @ $0289      ;Maximum number of Bytes in Keyboard Buffer ($0a)
+RPTFLG          @ $028a      ;Flag: Repeat keys setting
+KOUNT           @ $028b      ;Repeat Key: Speed Counter ($04)
+DELAY           @ $028c      ;Repeat Key: First repeat delay Counter ($10)
+SHFLAG          @ $028d      ;flags for shift, CBM, CTRL
+LSTSHF          @ $028e      ;Last Shift Key used for debouncing
+KEYLOG          @ $028f 2    ;Vector: Routine to determine Keyboard table to use
+MODE            @ $0291      ;Flag: Upper/Lower Case change
+AUTODN          @ $0292      ;Flag: Auto scroll down: $00 = Disabled ($00)
+M51CTR          @ $0293      ;RS232 Pseudo 6551 control Register Image
+M51CDR          @ $0294      ;RS232 Pseudo 6551 command Register Image
+M51AJB          @ $0295      ;RS232 Non-standard Bits/Second
+RSSTAT          @ $0297      ;RS232 Pseudo 6551 Status Register Image
+BITNUM          @ $0298      ;RS232 Number of Bits left to send
+BAUDOF          @ $0299      ;RS232 Baud Rate; Full Bit time microseconds
+RIDBE           @ $029b      ;RS232 Index to End of Input Buffer
+RIDBS           @ $029c 2    ;RS232 Pointer: High Byte of Address of Input Buffer
+RODBS           @ $029d 2    ;RS232 Pointer: High Byte of Address of Output Buffer
+RODBE           @ $029e      ;RS232 Index to End of Output Buffer
+IRQTMP          @ $029f 2    ;Temporary store for IRQ Vector during Tape operations
+ENABL           @ $02a1      ;RS232 Enables
+TODSNS          @ $02a2      ;TOD sense during Tape I/O
+TRDTMP          @ $02a3      ;Temporary storage during Tape READ
+TD1IRQ          @ $02a4      ;Temporary D1IRQ Indicator during Tape READ
+TLNIDX          @ $02a5      ;Temporary for Line Index
+TVSFLG          @ $02a6      ;Flag: TV Standard: $00 = NTSC, $01 = PAL
+CINV            @ $0314 2    ;Vector: Hardware IRQ Interrupt ($ea31)
+CNBINV          @ $0316 2    ;Vector: BRK Instruction Interrupt ($fe66)
+NMINV           @ $0318 2    ;Vector: Hardware NMI Interrupt ($fe47)
+IOPEN2          @ $031a 2    ;Vector: Kernal OPEN Routine ($f34a)
+ICLOSE2         @ $031c 2    ;Vector: Kernal CLOSE Routine ($f291)
+ICHKIN2         @ $031e 2    ;Vector: Kernal CHKIN Routine ($f20e)
+ICKOUT2         @ $0320 2    ;Vector: Kernal CHKOUT Routine ($f250)
+ICLRCH2         @ $0322 2    ;Vector: Kernal CLRCHN Routine ($f333)
+IBASIN2         @ $0324 2    ;Vector: Kernal CHRIN Routine ($f157)
+IBSOUT2         @ $0326 2    ;Vector: Kernal CHROUT Routine ($f1ca)
+ISTOP2          @ $0328 2    ;Vector: Kernal STOP Routine ($f6ed)
+IGETIN2         @ $032a 2    ;Vector: Kernal GETIN Routine ($f13e)
+ICLALL2         @ $032c 2    ;Vector: Kernal CLALL Routine ($f32f)
+USRCMD2         @ $032e 2    ;User Defined Vector ($fe66)
+ILOAD2          @ $0330 2    ;Vector: Kernal LOAD Routine ($f4a5)
+ISAVE2          @ $0332 2    ;Vector: Kernal SAVE Routine ($f5ed)
+TBUFFR          @ $033c 192  ;start of Tape I/O Buffer
+VICSCN          @ $0400 1024 ;start of Default Screen Video Matrix

--- a/SourceGen/RuntimeData/Commodore/C64-Kernal-ROM.sym65
+++ b/SourceGen/RuntimeData/Commodore/C64-Kernal-ROM.sym65
@@ -1,7 +1,3 @@
-https://raw.githubusercontent.com/c64cryptoboy/c64_ghidra/main/ghidra_scripts/c64LabelAddrs.py
-
---------------------------------------------------------------------------
-
 ; See the LICENSE file for distribution terms (Apache 2.0).
 ;
 ; Parts adapted from multiple sources:

--- a/SourceGen/RuntimeData/Commodore/C64-Kernal-ROM.sym65
+++ b/SourceGen/RuntimeData/Commodore/C64-Kernal-ROM.sym65
@@ -1,0 +1,255 @@
+https://raw.githubusercontent.com/c64cryptoboy/c64_ghidra/main/ghidra_scripts/c64LabelAddrs.py
+
+--------------------------------------------------------------------------
+
+; See the LICENSE file for distribution terms (Apache 2.0).
+;
+; Parts adapted from multiple sources:
+;
+; - Project 64, 64MAP10.TXT, June 1996, etext #41
+;   http://unusedino.de/ec64/technical/project64/memory_maps.html
+;
+; - PageTable's C64 BASIC & KERNAL ROM Disassembly
+;   https://www.pagetable.com/c64ref/c64disasm/
+;
+; - "Mapping the Commodore 64", by Sheldon Leemon
+;   Compute! Publications Inc. (1984), ISBN 0-942386-23-X 
+;   https://archive.org/details/Compute_s_Mapping_the_Commodore_64
+
+*SYNOPSIS KERNAL ROM ($e000-$ffff) labels (functions and some of the vectors)
+
+; Note: BASIC too big to fit into $a000-$bfff, so some additional BASIC support
+;       spills over into the start of the KERNAL ROM.
+
+expCont         @ $e000      ;EXP continued From BASIC ROM
+polyx           @ $e043      ;Series Evaluation
+rmulc           @ $e08d      ;Constants for RND
+rnd             @ $e097      ;Perform rnd
+bioerr          @ $e0f9      ;Handle I/O Error in BASIC
+bchout          @ $e10c      ;Output Character
+bchin           @ $e112      ;Input Character
+bckout          @ $e118      ;Set Up For Output
+bckin           @ $e11e      ;Set Up For Input
+bgetin          @ $e124      ;Get One Character
+sys             @ $e12a      ;Perform sys
+savet           @ $e156      ;Perform save
+verfyt          @ $e165      ;Perform verify / load
+opent           @ $e1be      ;Perform open
+closet          @ $e1c7      ;Perform close
+slpara          @ $e1d4      ;Get Parameters For LOAD/SAVE
+combyt          @ $e200      ;Get Next One Byte Parameter
+deflt           @ $e206      ;Check Default Parameters
+cmmerr          @ $e20e      ;Check For Comma
+ocpara          @ $e219      ;Get Parameters For OPEN/CLOSE
+cos             @ $e264      ;Perform cos
+sin             @ $e26b      ;Perform sin
+tan             @ $e2b4      ;Perform tan
+atn             @ $e30e      ;Perform atn
+bassft          @ $e37b      ;BASIC Warm Start RUNSTOP-RESTORE
+init            @ $e394      ;BASIC Cold Start
+initat          @ $e3a2      ;CHRGET For Zero-page
+initcz          @ $e3bf      ;Initialize BASIC RAM
+initms          @ $e422      ;Output Power-Up Message
+bvtrs           @ $e447 12   ;Table of BASIC Vectors (for $300)
+initv           @ $e453      ;Initialize Vectors
+words           @ $e45f      ;Power-Up Message
+chkoutCallPatch @ $e4ad      ;Patch for BASIC Call to CHKOUT
+rstCharColor    @ $e4da      ;Reset Character Colour
+pauseTapeFind   @ $e4e0      ;Pause After Finding Tape File
+rs232Timing     @ $e4ec 20   ;RS-232 Timing Table
+iobase2         @ $e500      ;Get I/O Address
+screen2         @ $e505      ;Get Screen Size
+plot2           @ $e50a      ;Put / Get Row And Column
+cint1           @ $e518      ;Initialize I/O
+clrScrn         @ $e544      ;Clear Screen
+homeCur         @ $e566      ;Home Cursor
+setScrnPtrs     @ $e56c      ;Set Screen Pointers
+ioDefaultsAlt   @ $e59a      ;Set I/O Defaults (Unused Entry)
+ioDefaults      @ $e5a0      ;Set I/O Defaults
+lp2             @ $e5b4      ;Get Character From Keyboard Buffer
+keyInput        @ $e5ca      ;Input From Keyboard
+keyScrnInput    @ $e632      ;Input From Screen or Keyboard
+quotesTest      @ $e684      ;Quotes Test
+scrnPrntInit    @ $e691      ;Set Up Screen Print
+advanceCur      @ $e6b6      ;Advance Cursor
+retreatCur      @ $e6ed      ;Retreat Cursor
+backPrevLine    @ $e701      ;Back on to Previous Line
+outputToScrn    @ $e716      ;Output to Screen
+unshiftChars    @ $e72a      ;unshifted characters
+shiftedChars    @ $e7d4      ;shifted characters
+nextLine        @ $e87c      ;Go to Next Line
+outputCR        @ $e891      ;Output <CR>
+chkLineDec      @ $e8a1      ;Check Line Decrement
+chkLineInc      @ $e8b3      ;Check Line Increment
+setColorCode    @ $e8cb      ;Set Colour Code
+colorCodeTbl    @ $e8da 16   ;Colour Code Table
+scrnScroll      @ $e8ea      ;Scroll Screen
+openSpace       @ $e965      ;Open A Space On The Screen
+moveLine        @ $e9c8      ;Move A Screen Line
+syncColorXfer   @ $e9e0      ;Syncronise Colour Transfer
+setSOL          @ $e9f0      ;Set Start of Line
+clearLine       @ $e9ff      ;Clear Screen Line
+printToScrn     @ $ea13      ;Print To Screen
+syncColPntr     @ $ea24      ;Syncronise Colour Pointer
+defaultIrqEntry @ $ea31      ;Main IRQ Entry Point
+scnkey2         @ $ea87      ;Scan Keyboard
+processKey      @ $eadd      ;Process Key Image
+graphTextCntrl  @ $ec44      ;Graphics/Text Control
+shiftRunEq      @ $ece7      ;Shift-Run Equivalent
+loScrnLineAddr  @ $ecf0      ;Low Byte Screen Line Addresses
+talk2           @ $ed09      ;Send TALK Command on Serial Bus
+listn2          @ $ed0c      ;Send LISTEN Command on Serial Bus
+serialSend      @ $ed40      ;Send Data On Serial Bus
+flagErrors      @ $edad      ;Flag Errors
+flagDevNotPres  @ $edad      ;Status #80 - device not present
+flagWriteTout   @ $edb0      ;Status #03 - write timeout
+secnd2          @ $edb9      ;Send LISTEN Secondary Address
+clrAtn          @ $edbe      ;Clear ATN
+tksa2           @ $edc7      ;Send TALK Secondary Address
+waitForClock    @ $edcc      ;Wait For Clock
+ciout2          @ $eddd      ;Send Serial Deferred
+untalk2         @ $edef      ;Send UNTALK / UNLISTEN
+unlsn2          @ $edfe      ;Unlisten
+acptr2          @ $ee13      ;Receive From Serial Bus
+serialClkOn     @ $ee85      ;Serial Clock On
+serialClkOff    @ $ee8e      ;Serial Clock Off
+serialOutput1   @ $ee97      ;Serial Output 1
+serialOutput0   @ $eea0      ;Serial Output 0
+serialGet       @ $eea9      ;Get Serial Data And Clock In
+delay1ms        @ $eeb3      ;Delay 1 ms
+rs232Send       @ $eebb      ;RS-232 Send
+rs232SendByte   @ $ef06      ;Send New RS-232 Byte
+noDataSetRdy    @ $ef2e      ;No DSR / No CTS Error
+disableTimer    @ $ef39      ;Disable Timer
+bitCount        @ $ef4a      ;Compute Bit Count
+rs232Recv       @ $ef59      ;RS-232 Receive
+rs232RecvInit   @ $ef7e      ;Set Up To Receive
+rs232ProcByte   @ $ef90      ;Process RS-232 Byte
+rs232Submit     @ $efe1      ;Submit to RS-232
+noDsrError      @ $f00d      ;No DSR (Data Set Ready) Error
+rs232SendToBuf  @ $f017      ;Send to RS-232 Buffer
+rs232Input      @ $f04d      ;Input From RS-232
+rs232Get        @ $f086      ;Get From RS-232
+serialBusIdle   @ $f0a4      ;Serial Bus Idle
+prtMsgIfDirect  @ $f12b      ;Print Message if Direct
+prtMsg          @ $f12f      ;Print Message
+getin3          @ $f13e      ;Get a byte
+chrin3          @ $f157      ;Input a byte
+getFromIO       @ $f199      ;Get From Tape / Serial / RS-232
+chrout3         @ $f1ca      ;Output One Character
+chkin3          @ $f20e      ;Set Input Device
+chkout3         @ $f250      ;Set Output Device
+close3          @ $f291      ;Close File
+findFile        @ $f30f      ;Find File
+setFileParms    @ $f31f      ;Set File values
+clall3          @ $f32f      ;Abort All Files
+clrchn3         @ $f333      ;Restore Default I/O
+open3           @ $f34a      ;Open File
+setSecondary    @ $f3d5      ;Send Secondary Address
+rs232Open       @ $f409      ;Open RS-232
+load2           @ $f49e      ;Load RAM
+serialLoadFile  @ $f4b8      ;Load File From Serial Bus
+tapeLoadFile    @ $f533      ;Load File From Tape
+printSearching  @ $f5af      ;Print SEARCHING
+printFilename   @ $f5c1      ;Print Filename
+printLoading    @ $f5d2      ;Print LOADING / VERIFYING
+save            @ $f5dd      ;Save RAM
+serialSave      @ $f5fa      ;Save to Serial Bus
+tapeSave        @ $f659      ;Save to Tape
+printSaving     @ $f68f      ;Print SAVING
+udtim2          @ $f69b      ;Bump Clock
+rdtim2          @ $f6dd      ;Get Time
+settim2         @ $f6e4      ;Set Time
+stop            @ $f6ed      ;Check STOP Key
+findTapeHdr     @ $f72c      ;Find Any Tape Header
+writeTapeHdr    @ $f76a      ;Write Tape Header
+getBufAddr      @ $f7d0      ;Get Buffer Address
+headerStartEnd  @ $f7d7      ;Set Buffer Stat / End Pointers
+findSpecTapeHdr @ $f7ea      ;Find Specific Tape Header
+bumpTapePtr     @ $f80d      ;Bump Tape Pointer
+printPressPlay  @ $f817      ;Print PRESS PLAY ON TAPE
+chkTapeStatus   @ $f82e      ;Check Tape Status
+printPressRecrd @ $f838      ;Print PRESS RECORD...
+initTapeRead    @ $f841      ;Initiate Tape Read
+initTapeWrite   @ $f864      ;Initiate Tape Write
+tapeOperEntry   @ $f875      ;Common Tape Code
+chkTapeStop     @ $f8d0      ;Check Tape Stop
+setReadTiming   @ $f8e2      ;Set Read Timing
+readTapeBits    @ $f92c      ;Read Tape Bits
+storeTapeChars  @ $fa60      ;Store Tape Characters
+rstTapePtr      @ $fb8e      ;Reset Tape Pointer
+newCharSetup    @ $fb97      ;New Character Setup
+sendTapeTone    @ $fba6      ;Send Tone to Tape
+writeTapeData   @ $fbc8      ;Write Data to Tape
+tapeIrqEntry    @ $fbcd      ;IRQ Entry Point
+writeTapeLeader @ $fc57      ;Write Tape Leader
+restoreIrq      @ $fc93      ;Restore Normal IRQ
+setIrqVec       @ $fcb8      ;Set IRQ Vector
+stopTapeMotor   @ $fcca      ;Kill Tape Motor
+chkRwPtr        @ $fcd1      ;Check Read / Write Pointer
+bumpRwPtr       @ $fcdb      ;Bump Read / Write Pointer
+resetEntry      @ $fce2      ;Power-Up RESET Entry
+cartridgeCheck  @ $fd02      ;Check For 8-ROM
+restor2         @ $fd15      ;Restore Kernal Vectors (at $0314)
+vector2         @ $fd1a      ;Change Vectors For User
+ramtas2         @ $fd50      ;Initialise System Constants
+ioinit2         @ $fda3      ;Initialise I/O
+enableTimer     @ $fddd      ;Enable Timer
+setnam2         @ $fdf9      ;Set Filename
+setlfs2         @ $fe00      ;Set Logical File Parameters
+readst2         @ $fe07      ;Get I/O Status Word
+setmsg2         @ $fe18      ;Control OS Messages
+settmo2         @ $fe21      ;Set IEEE Timeout
+memtop2         @ $fe25      ;Read / Set Top of Memory
+membot2         @ $fe34      ;Read / Set Bottom of Memory
+nmiHandler      @ $fe43      ;NMI Transfer Entry
+basicWarmStart  @ $fe66      ;Warm Start Basic BRK
+exitInterrupt   @ $febc      ;Exit Interrupt
+rs232NmiIn      @ $fed6      ;NMI RS-232 In
+rs232NmiOut     @ $ff07      ;NMI RS-232 Out
+irqEntryAlt     @ $ff43      ;Fake IRQ Entry
+irqEntry        @ $ff48      ;IRQ Entry
+cint2           @ $ff5b      ;Initialize screen editor
+kernalVer       @ $ff80      ;Kernal Version Number 03
+cint            @ $ff81      ;Init Editor & Video Chips ($ff5b)
+ioinit          @ $ff84      ;Init I/O Devices  Ports & Timers ($fda3)
+ramtas          @ $ff87      ;Init Ram & Buffers ($fd50)
+restor          @ $ff8a      ;Restore Vectors ($fd15)
+vector          @ $ff8d      ;Change Vectors For User ($fd1a)
+setmsg          @ $ff90      ;Control OS Messages ($fe18)
+secnd           @ $ff93      ;Send SA After Listen ($edb9)
+tksa            @ $ff96      ;Send SA After Talk ($edc7)
+memtop          @ $ff99      ;Set/Read System RAM Top ($fe25)
+membot          @ $ff9c      ;Set/Read System RAM Bottom ($fe34)
+scnkey          @ $ff9f      ;Scan Keyboard ($ea87)
+settmo          @ $ffa2      ;Set Timeout In IEEE ($fe21)
+acptr           @ $ffa5      ;Handshake Serial Byte In ($ee13)
+ciout           @ $ffa8      ;Handshake Serial Byte Out ($eddd)
+untalk          @ $ffab      ;Command Serial Bus UNTALK ($edef)
+unlsn           @ $ffae      ;Command Serial Bus UNLISTEN ($edfe)
+listn           @ $ffb1      ;Command Serial Bus LISTEN ($ed0c)
+talk            @ $ffb4      ;Command Serial Bus TALK ($ed09)
+readst          @ $ffb7      ;Read I/O Status Word ($fe07)
+setlfs          @ $ffba      ;Set Logical File Parameters ($fe00)
+setnam          @ $ffbd      ;Set Filename ($fdf9)
+iopen           @ $ffc0      ;Open Vector $f34a ($031a->$f34a)
+iclose          @ $ffc3      ;Close Vector $f291 ($031c->$f291)
+ichkin          @ $ffc6      ;Set Input $f20e ($031e->$f20e)
+ichkout         @ $ffc9      ;Set Output $f250 ($0320->$f250)
+iclrch          @ $ffcc      ;Restore I/O Vector $f333 ($0322->$f333)
+ichrin          @ $ffcf      ;Input Vector chrin $f157 ($0324->$f157)
+ichrout         @ $ffd2      ;Output Vector chrout $f1ca ($0326->$f1ca)
+load            @ $ffd5      ;Load RAM From Device ($f49e)
+save2           @ $ffd8      ;Save RAM To Device ($f5dd)
+settim          @ $ffdb      ;Set Real-Time Clock ($f6e4)
+rdtim           @ $ffde      ;Read Real-Time Clock ($f6dd)
+istop3          @ $ffe1      ;Test-Stop Vector $f6ed ($0328->$f6ed)
+igetin          @ $ffe4      ;Get From Keyboad $f13e ($032a->$f13e)
+iclall          @ $ffe7      ;Close All Channels And Files $f32f ($032c->$f32f)
+udtim           @ $ffea      ;Increment Real-Time Clock ($f69b)
+screen          @ $ffed      ;Return Screen Organization ($e505)
+plot            @ $fff0      ;Read / Set Cursor X/Y Position ($e50a)
+iobase          @ $fff3      ;Return I/O Base Address ($e500)
+nmiVector       @ $fffa 2    ;Non-Maskable Interrupt Hardware Vector ($fe43)
+resetVector     @ $fffc 2    ;System Rest (RES) Hardware Vector ($fce2)
+irqVector       @ $fffe 2    ;Maskable Interrupt Request and Break Hardware Vectors ($ff48)


### PR DESCRIPTION
Additional symbol files:  These include labels for ROMs and those ROMs' specific use of RAM addresses.  6 new files covering the Kernal, BASIC, and the 1541 (a 6502-driven floppy drive you can send code to for independent execution).
I'm thinking that "C64-Kernal-ROM.sym65" should not replace "C64-Kernal.sym65", as the latter is a nice very-lightweight (and default) demonstration of symbol inclusion for C64 projects.

I also made the range addition to the colorRam entry in "C64-IO-sym65" that was suggested on the last pull request.